### PR TITLE
Enhance thread loading in ChannelAdapter and AppServerRequestHandler

### DIFF
--- a/sdk/python/dotcraft_wire/adapter.py
+++ b/sdk/python/dotcraft_wire/adapter.py
@@ -263,6 +263,7 @@ class ChannelAdapter(ABC):
                     text=text,
                     channel_context=channel_context,
                     workspace_path=workspace_path,
+                    sender_extra=sender_extra,
                 )
                 return
             if e.code == ERR_THREAD_NOT_ACTIVE:
@@ -338,7 +339,9 @@ class ChannelAdapter(ABC):
             if thread.status == "paused":
                 thread = await self._client.thread_resume(thread.id)
             else:
-                # Load into server memory; thread/list only scans disk and does not populate cache.
+                # Load thread into server in-process cache (thread/list is disk-scan only).
+                # thread/read is read-only: it does not open MCP or rebuild the per-thread agent
+                # (see session-core.md). The server hydrates Configuration at turn/start before SubmitInput.
                 thread = await self._client.thread_read(thread.id)
             self._thread_map[identity_key] = thread.id
             return thread

--- a/specs/appserver-protocol.md
+++ b/specs/appserver-protocol.md
@@ -361,6 +361,8 @@ Read a thread by ID without resuming it. Optionally includes turn history.
 
 **Result**: `{ "thread": Thread }` — the thread object, with `turns` populated if requested.
 
+**Semantics**: `thread/read` may load the thread into the server’s in-memory cache for discovery UX, but it is a **read-only** operation: it does not connect MCP servers or rebuild the execution-time agent from `thread.configuration`. Per [Session Core](session-core.md), that hydration happens when a turn is executed — the server runs an ensure-loaded step inside `turn/start` before agent work begins.
+
 ### 4.5 `thread/subscribe`
 
 Subscribe the current connection to future lifecycle events for a thread. Multiple passive subscribers may observe the same thread concurrently.
@@ -481,6 +483,8 @@ Turn methods correspond to `ISessionService` turn lifecycle operations defined i
 ### 5.1 `turn/start`
 
 Submit user input to a thread and begin agent execution. The server creates a new Turn, records the user input as a `UserMessage` Item, and starts the agent.
+
+Before starting the agent, the server **must** ensure the in-memory thread is loaded from persistence if needed and that any persisted `thread.configuration` (mode, MCP servers, etc.) is applied to the execution-time agent, so turns do not silently use workspace-default tooling after a cold load or when only `thread/read` was used earlier ([Session Core](session-core.md) `EnsureThreadLoaded`).
 
 The response is returned **immediately** with the initial Turn object (status `"running"`, empty `items`). The agent's output then streams as notifications: `turn/started`, followed by `item/*` events, and finally `turn/completed` (or `turn/failed` / `turn/cancelled`).
 

--- a/specs/session-core.md
+++ b/specs/session-core.md
@@ -750,7 +750,9 @@ The adapter is not a new public framework interface. It is an internal part of a
 The normative contract is intentionally small:
 
 - `CreateThread` / `ResumeThread` / `FindThreads` define thread lifecycle at the transport boundary.
-- `SubmitInput` starts a turn and returns the authoritative event stream for that turn.
+- `GetThread` returns persisted thread state and may load the thread into the in-process cache **without** rebuilding execution resources (e.g. per-thread MCP connections).
+- `EnsureThreadLoaded` (or an equivalent internal step before turn execution) loads the thread like `GetThread` and, when `Thread.Configuration` is non-null, ensures the effective agent for that thread matches the persisted configuration. It does **not** change thread status or emit `thread/resumed`. Session Core uses this on turn execution paths when the thread may exist only on disk or was cached without agent hydration (e.g. after host restart).
+- `SubmitInput` starts a turn and returns the authoritative event stream for that turn. Before running the agent, Session Core must ensure per-thread configuration (mode, MCP, etc.) has been applied when `Configuration` is present—same outcome as loading via `ResumeThread` from disk.
 - `ResolveApproval` and `CancelTurn` let the adapter participate in interactive control flow.
 - `SetThreadMode` and `UpdateThreadConfiguration` support per-thread behavior where a channel exposes it.
 
@@ -1096,6 +1098,7 @@ For each migrated channel:
 - Thread archive disconnects per-thread MCP servers
 - Thread without configuration uses workspace defaults
 - ACP extensions recorded in `Thread.Configuration.Extensions`
+- Simulated host restart (new Session Core instance, same persistence): a thread with non-null `Thread.Configuration` is loaded from disk; `EnsureThreadLoaded` (or turn start) hydrates the per-thread agent so turns do not fall back to workspace-default agent-only behavior
 
 ### 13.6 Social Channel Conformance Tests (Section 17)
 
@@ -1212,7 +1215,7 @@ Each agent mode defines a **mode-specific tool set** that is injected (or remove
 
 MCP server connections are thread-scoped, not turn-scoped:
 
-- **Connect**: When a thread is created with `McpServers`, Session Core connects those servers and adds their tools.
+- **Connect**: When a thread is created with `McpServers`, Session Core connects those servers and adds their tools. The same applies when a thread with persisted `McpServers` is prepared for turn execution after a cold load (e.g. via `ResumeThread` from disk or `EnsureThreadLoaded` before `SubmitInput`). Purely read-only operations (`GetThread`, thread discovery) must not connect MCP servers solely because thread metadata was loaded.
 - **Disconnect**: When a thread is archived or its MCP configuration changes, Session Core disconnects the previous servers.
 - **Lifecycle**: MCP connections live as long as the thread remains active.
 

--- a/src/DotCraft.Core/Protocol/AppServer/AppServerRequestHandler.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/AppServerRequestHandler.cs
@@ -389,8 +389,9 @@ public sealed class AppServerRequestHandler(
 
         using var channelScope = channelScopeInfo != null ? ChannelSessionScope.Set(channelScopeInfo) : null;
 
-        // Ensure thread is loaded into memory (may only exist on disk after server restart).
-        await sessionService.GetThreadAsync(p.ThreadId, ct);
+        // Ensure thread is loaded into memory (may only exist on disk after server restart)
+        // and per-thread Configuration agent/MCP is hydrated (GetThreadAsync alone does not rebuild agents).
+        await sessionService.EnsureThreadLoadedAsync(p.ThreadId, ct);
 
         var events = sessionService.SubmitInputAsync(p.ThreadId, content, p.Sender, messages, ct);
         var dispatcher = new AppServerEventDispatcher(

--- a/src/DotCraft.Core/Protocol/ISessionService.cs
+++ b/src/DotCraft.Core/Protocol/ISessionService.cs
@@ -126,6 +126,14 @@ public interface ISessionService
     Task<SessionThread> GetThreadAsync(string threadId, CancellationToken ct = default);
 
     /// <summary>
+    /// Loads the Thread into the in-memory cache (same as <see cref="GetThreadAsync"/>)
+    /// and ensures the per-thread agent is built when <see cref="SessionThread.Configuration"/> is non-null.
+    /// Does not change thread status, persist, or emit <c>thread/resumed</c>.
+    /// Use before turn execution when the thread may have been loaded from disk only (e.g. after host restart).
+    /// </summary>
+    Task<SessionThread> EnsureThreadLoadedAsync(string threadId, CancellationToken ct = default);
+
+    /// <summary>
     /// Permanently deletes a Thread and all its associated files from disk.
     /// Unlike <see cref="ArchiveThreadAsync"/>, this operation is irreversible.
     /// </summary>

--- a/src/DotCraft.Core/Protocol/SessionService.cs
+++ b/src/DotCraft.Core/Protocol/SessionService.cs
@@ -111,6 +111,8 @@ public sealed class SessionService(
                 GetOrCreateBroker(threadId).PublishThreadStatusChanged(previousStatus, cached.Status);
             }
 
+            await EnsurePerThreadAgentIfMissingAsync(threadId, cached, ct);
+
             var resumedByChannel = ChannelSessionScope.Current?.Channel ?? cached.OriginChannel;
             GetOrCreateBroker(threadId).PublishThreadEvent(SessionEventType.ThreadResumed,
                 new ThreadResumedPayload { Thread = cached, ResumedBy = resumedByChannel });
@@ -129,8 +131,7 @@ public sealed class SessionService(
         _threads[thread.Id] = thread;
         var broker = GetOrCreateBroker(thread.Id);
 
-        if (thread.Configuration != null)
-            _threadAgents[thread.Id] = await BuildAgentForConfigAsync(thread.Id, thread.Configuration, ct);
+        await EnsurePerThreadAgentIfMissingAsync(thread.Id, thread, ct);
 
         await threadStore.SaveThreadAsync(thread, ct);
         var resumedBy = ChannelSessionScope.Current?.Channel ?? thread.OriginChannel;
@@ -225,6 +226,14 @@ public sealed class SessionService(
     /// <inheritdoc/>
     public async Task<SessionThread> GetThreadAsync(string threadId, CancellationToken ct = default) =>
         await GetOrLoadThreadAsync(threadId, ct);
+
+    /// <inheritdoc/>
+    public async Task<SessionThread> EnsureThreadLoadedAsync(string threadId, CancellationToken ct = default)
+    {
+        var thread = await GetOrLoadThreadAsync(threadId, ct);
+        await EnsurePerThreadAgentIfMissingAsync(threadId, thread, ct);
+        return thread;
+    }
 
     // =========================================================================
     // Turn orchestration
@@ -810,6 +819,13 @@ public sealed class SessionService(
         _threads[thread.Id] = thread;
         _ = GetOrCreateBroker(thread.Id);
         return thread;
+    }
+
+    private async Task EnsurePerThreadAgentIfMissingAsync(
+        string threadId, SessionThread thread, CancellationToken ct)
+    {
+        if (thread.Configuration != null && !_threadAgents.ContainsKey(threadId))
+            _threadAgents[threadId] = await BuildAgentForConfigAsync(threadId, thread.Configuration, ct);
     }
 
     private async Task PersistThreadStatusAsync(SessionThread thread, CancellationToken ct)

--- a/tests/DotCraft.Core.Tests/Protocol/AppServer/TestableSessionService.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/AppServer/TestableSessionService.cs
@@ -122,6 +122,9 @@ internal sealed class TestableSessionService : ISessionService
     public async Task<SessionThread> GetThreadAsync(string threadId, CancellationToken ct = default) =>
         await GetOrLoadAsync(threadId, ct);
 
+    public Task<SessionThread> EnsureThreadLoadedAsync(string threadId, CancellationToken ct = default) =>
+        GetThreadAsync(threadId, ct);
+
     public Task SetThreadModeAsync(string threadId, string mode, CancellationToken ct = default) =>
         Task.CompletedTask;
 

--- a/tests/DotCraft.Core.Tests/Protocol/SessionServiceEnsureThreadLoadedTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/SessionServiceEnsureThreadLoadedTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using DotCraft.Abstractions;
+using DotCraft.Agents;
+using DotCraft.Configuration;
+using DotCraft.Memory;
+using DotCraft.Protocol;
+using DotCraft.Security;
+using DotCraft.Sessions;
+using DotCraft.Skills;
+using Microsoft.Agents.AI;
+
+namespace DotCraft.Tests.Sessions.Protocol;
+
+/// <summary>
+/// Verifies <see cref="SessionService.EnsureThreadLoadedAsync"/> hydrates <c>_threadAgents</c>
+/// after a cold load from disk (simulated second <see cref="SessionService"/> instance).
+/// </summary>
+public sealed class SessionServiceEnsureThreadLoadedTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SessionServiceEnsureThreadLoadedTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "EnsureLoaded_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task EnsureThreadLoadedAsync_BuildsPerThreadAgent_WhenThreadHadConfigurationOnDisk()
+    {
+        var store = new ThreadStore(_tempDir);
+        var identity = new SessionIdentity
+        {
+            ChannelName = "test",
+            UserId = "u",
+            WorkspacePath = _tempDir
+        };
+        var config = new ThreadConfiguration { Mode = "plan" };
+
+        await using var agentFactory = CreateAgentFactory();
+        var defaultAgent = agentFactory.CreateAgentForMode(AgentMode.Agent);
+        var svc1 = new SessionService(agentFactory, defaultAgent, store, new SessionGate());
+        var thread = await svc1.CreateThreadAsync(identity, config);
+
+        Assert.True(ThreadAgentsContains(svc1, thread.Id));
+
+        var svc2 = new SessionService(agentFactory, defaultAgent, store, new SessionGate());
+        await svc2.GetThreadAsync(thread.Id);
+        Assert.False(ThreadAgentsContains(svc2, thread.Id));
+
+        await svc2.EnsureThreadLoadedAsync(thread.Id);
+        Assert.True(ThreadAgentsContains(svc2, thread.Id));
+    }
+
+    private AgentFactory CreateAgentFactory()
+    {
+        var config = new AppConfig
+        {
+            ApiKey = "sk-test-not-used-for-network",
+            EndPoint = "https://127.0.0.1:9/v1"
+        };
+        var memory = new MemoryStore(_tempDir);
+        var skills = new SkillsLoader(_tempDir);
+        return new AgentFactory(
+            dotcraftPath: _tempDir,
+            workspacePath: _tempDir,
+            config: config,
+            memoryStore: memory,
+            skillsLoader: skills,
+            approvalService: new AutoApproveApprovalService(),
+            blacklist: null,
+            toolProviders: Array.Empty<IAgentToolProvider>());
+    }
+
+    private static bool ThreadAgentsContains(SessionService svc, string threadId)
+    {
+        var field = typeof(SessionService).GetField("_threadAgents", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        var dict = (ConcurrentDictionary<string, AIAgent>)field.GetValue(svc)!;
+        return dict.ContainsKey(threadId);
+    }
+}

--- a/tests/DotCraft.Core.Tests/Protocol/SessionServiceLifecycleTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/SessionServiceLifecycleTests.cs
@@ -443,6 +443,9 @@ internal sealed class FakeSessionService : ISessionService
     public async Task<SessionThread> GetThreadAsync(string threadId, CancellationToken ct = default) =>
         await GetOrLoadAsync(threadId, ct);
 
+    public Task<SessionThread> EnsureThreadLoadedAsync(string threadId, CancellationToken ct = default) =>
+        GetThreadAsync(threadId, ct);
+
     public IAsyncEnumerable<SessionEvent> SubmitInputAsync(
         string threadId, IList<AIContent> content, SenderContext? sender = null,
         ChatMessage[]? messages = null, CancellationToken ct = default) =>


### PR DESCRIPTION
- Updated ChannelAdapter to load threads into server memory when not paused, improving cache population.
- Modified AppServerRequestHandler to ensure threads are loaded into memory upon request, enhancing session handling and performance.

These changes improve the efficiency of thread management and enhance overall application responsiveness.