### PR TITLE
refactor: simplify CreateChannelService method signatures across modules

### DIFF
--- a/src/DotCraft.AGUI/AGUIModule.cs
+++ b/src/DotCraft.AGUI/AGUIModule.cs
@@ -25,6 +25,6 @@ public sealed partial class AGUIModule : ModuleBase
     public override IEnumerable<IAgentToolProvider> GetToolProviders() => [];
 
     /// <inheritdoc />
-    public override IChannelService CreateChannelService(IServiceProvider sp, ModuleContext context)
+    public override IChannelService CreateChannelService(IServiceProvider sp)
         => ActivatorUtilities.CreateInstance<AGUIChannelService>(sp);
 }

--- a/src/DotCraft.Api/ApiModule.cs
+++ b/src/DotCraft.Api/ApiModule.cs
@@ -45,6 +45,6 @@ public sealed partial class ApiModule : ModuleBase
         => [];
 
     /// <inheritdoc />
-    public override IChannelService CreateChannelService(IServiceProvider sp, ModuleContext context)
+    public override IChannelService CreateChannelService(IServiceProvider sp)
         => ActivatorUtilities.CreateInstance<ApiChannelService>(sp);
 }

--- a/src/DotCraft.App/Channels/ChannelRunner.cs
+++ b/src/DotCraft.App/Channels/ChannelRunner.cs
@@ -74,7 +74,7 @@ public sealed class ChannelRunner : IAsyncDisposable
         ModuleRegistry registry)
     {
         var traceStore = sp.GetService<TraceStore>();
-        var native = CollectNativeChannels(sp, config, paths, registry);
+        var native = CollectNativeChannels(sp, config, registry);
         var hasExternal = ExternalChannelManager.HasEnabledChannels(config);
         var wantDashboard = config.DashBoard.Enabled && traceStore != null;
 
@@ -112,20 +112,12 @@ public sealed class ChannelRunner : IAsyncDisposable
     private static List<IChannelService> CollectNativeChannels(
         IServiceProvider sp,
         AppConfig config,
-        DotCraftPaths paths,
         ModuleRegistry registry)
     {
-        var subContext = new ModuleContext
-        {
-            Config = config,
-            Paths = paths,
-            ServiceProvider = sp
-        };
-
         return registry
             .GetEnabledModules(config)
             .Where(m => m.Name is not ("gateway" or "app-server"))
-            .Select(m => m.CreateChannelService(sp, subContext))
+            .Select(m => m.CreateChannelService(sp))
             .OfType<IChannelService>()
             .ToList();
     }
@@ -133,7 +125,7 @@ public sealed class ChannelRunner : IAsyncDisposable
     /// <summary>
     /// Ensures DashBoard / native HTTP channels do not bind the same (host, port) as the AppServer WebSocket listener.
     /// </summary>
-    public static void ValidateAppServerPortConflict(AppConfig config, IReadOnlyList<IChannelService> nativeChannels)
+    private static void ValidateAppServerPortConflict(AppConfig config, IReadOnlyList<IChannelService> nativeChannels)
     {
         var appServer = config.GetSection<AppServerConfig>("AppServer");
         if (appServer.Mode is not (AppServerMode.WebSocket or AppServerMode.StdioAndWebSocket))

--- a/src/DotCraft.App/Gateway/GatewayModule.cs
+++ b/src/DotCraft.App/Gateway/GatewayModule.cs
@@ -59,18 +59,11 @@ public sealed class GatewayHostFactory : IHostFactory
         var registry = sp.GetRequiredService<ModuleRegistry>();
         var config = sp.GetRequiredService<AppConfig>();
 
-        var subContext = new ModuleContext
-        {
-            Config = config,
-            Paths = context.Paths,
-            ServiceProvider = sp
-        };
-
         // Collect channel services from all enabled non-gateway modules
         var channelServices = registry
             .GetEnabledModules(config)
             .Where(m => m.Name != "gateway")
-            .Select(m => m.CreateChannelService(sp, subContext))
+            .Select(m => m.CreateChannelService(sp))
             .OfType<IChannelService>()
             .ToList();
 

--- a/src/DotCraft.App/Program.cs
+++ b/src/DotCraft.App/Program.cs
@@ -156,6 +156,16 @@ var paths = new DotCraftPaths
 
 var moduleRegistry = new ModuleRegistry();
 ModuleRegistrations.RegisterAll(moduleRegistry);
+
+// Module config validation
+var configValidationOk = ServiceRegistration.ValidateConfigurations(config, moduleRegistry);
+if (!configValidationOk && isHeadless)
+{
+    await Console.Error.WriteLineAsync("Configuration validation failed.");
+    Environment.Exit(1);
+    return;
+}
+
 var hostBuilder = new HostBuilder(moduleRegistry, config, paths);
 
 var services = new ServiceCollection()

--- a/src/DotCraft.Automations/AutomationsModule.cs
+++ b/src/DotCraft.Automations/AutomationsModule.cs
@@ -47,7 +47,7 @@ public sealed partial class AutomationsModule : ModuleBase
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IOrchestratorSnapshotProvider, AutomationsDashboardSnapshotProvider>());
     }
 
-    public override IChannelService? CreateChannelService(IServiceProvider sp, ModuleContext context) =>
+    public override IChannelService CreateChannelService(IServiceProvider sp) =>
         ActivatorUtilities.CreateInstance<AutomationsChannelService>(sp);
 
     /// <inheritdoc />

--- a/src/DotCraft.Core/Abstractions/IDotCraftModule.cs
+++ b/src/DotCraft.Core/Abstractions/IDotCraftModule.cs
@@ -47,9 +47,8 @@ public interface IDotCraftModule
     /// Returns null if the module does not support channel service mode.
     /// </summary>
     /// <param name="sp">The service provider with all shared DI services available.</param>
-    /// <param name="context">The module context containing configuration and paths.</param>
     /// <returns>A channel service instance, or null if not supported.</returns>
-    IChannelService? CreateChannelService(IServiceProvider sp, ModuleContext context) => null;
+    IChannelService? CreateChannelService(IServiceProvider sp) => null;
 
     /// <summary>
     /// Gets the tool providers contributed by this module.

--- a/src/DotCraft.Core/Abstractions/ModuleBase.cs
+++ b/src/DotCraft.Core/Abstractions/ModuleBase.cs
@@ -28,7 +28,7 @@ public abstract class ModuleBase : IDotCraftModule
     public virtual IReadOnlyList<string> ValidateConfig(AppConfig config) => [];
 
     /// <inheritdoc />
-    public virtual IChannelService? CreateChannelService(IServiceProvider sp, ModuleContext context) => null;
+    public virtual IChannelService? CreateChannelService(IServiceProvider sp) => null;
 
     /// <inheritdoc />
     public virtual IEnumerable<IAgentToolProvider> GetToolProviders() => [];

--- a/src/DotCraft.Core/Abstractions/ModuleContext.cs
+++ b/src/DotCraft.Core/Abstractions/ModuleContext.cs
@@ -17,9 +17,4 @@ public sealed class ModuleContext
     /// The workspace and bot paths.
     /// </summary>
     public required DotCraftPaths Paths { get; init; }
-
-    /// <summary>
-    /// The service provider for resolving dependencies.
-    /// </summary>
-    public IServiceProvider? ServiceProvider { get; init; }
 }

--- a/src/DotCraft.Core/Configuration/ConfigValidator.cs
+++ b/src/DotCraft.Core/Configuration/ConfigValidator.cs
@@ -20,6 +20,7 @@ public sealed class ConfigValidator(ModuleRegistry moduleRegistry)
 
         foreach (var module in moduleRegistry.Modules)
         {
+            if (!module.IsEnabled(config)) continue;
             var errors = module.ValidateConfig(config);
             if (errors.Count > 0)
                 result[module.Name] = errors;

--- a/src/DotCraft.Core/Hosting/HostBuilder.cs
+++ b/src/DotCraft.Core/Hosting/HostBuilder.cs
@@ -64,8 +64,7 @@ public sealed class HostBuilder
             var context = new ModuleContext
             {
                 Config = _config,
-                Paths = _paths,
-                ServiceProvider = serviceProvider
+                Paths = _paths
             };
             return factory.CreateHost(serviceProvider, context);
         }

--- a/src/DotCraft.QQ/QQModule.cs
+++ b/src/DotCraft.QQ/QQModule.cs
@@ -61,6 +61,6 @@ public sealed partial class QQModule : ModuleBase
         => [new QQToolProvider()];
 
     /// <inheritdoc />
-    public override IChannelService CreateChannelService(IServiceProvider sp, ModuleContext context)
+    public override IChannelService CreateChannelService(IServiceProvider sp)
         => ActivatorUtilities.CreateInstance<QQChannelService>(sp);
 }

--- a/src/DotCraft.WeCom/WeComModule.cs
+++ b/src/DotCraft.WeCom/WeComModule.cs
@@ -59,6 +59,6 @@ public sealed partial class WeComModule : ModuleBase
         => [new WeComToolProvider()];
 
     /// <inheritdoc />
-    public override IChannelService CreateChannelService(IServiceProvider sp, ModuleContext context)
+    public override IChannelService CreateChannelService(IServiceProvider sp)
         => ActivatorUtilities.CreateInstance<WeComChannelService>(sp);
 }


### PR DESCRIPTION
- Updated the CreateChannelService method in multiple modules to remove the ModuleContext parameter, streamlining the service creation process.
- Adjusted related implementations in AGUIModule, ApiModule, AutomationsModule, QQModule, and WeComModule for consistency.
- Removed unnecessary ModuleContext usage in ChannelRunner and GatewayModule, enhancing clarity and reducing complexity.
- Added configuration validation in Program.cs to ensure proper module setup before application execution.