### PR TITLE
Implement model catalog management and enhance user experience

### DIFF
--- a/desktop/e2e/smoke.ts
+++ b/desktop/e2e/smoke.ts
@@ -262,7 +262,7 @@ async function run(): Promise<void> {
     // ── Step 4: New thread ────────────────────────────────────────────────
     log('STEP 4: Creating new thread...')
     await page.click('button[title="New Thread (Ctrl+N)"]')
-    await page.waitForSelector('textarea[placeholder="Ask DotCraft anything"]', {
+    await page.waitForSelector('textarea[placeholder="Ask DotCraft anything…"]', {
       timeout: STEP_TIMEOUT
     })
     await screenshot('new-thread')
@@ -310,8 +310,8 @@ async function run(): Promise<void> {
     // ── Step 5: Type message ──────────────────────────────────────────────
     const testMessage = 'Please say exactly "E2E test OK" and nothing else.'
     log(`STEP 5: Typing: "${testMessage}"`)
-    await page.click('textarea[placeholder="Ask DotCraft anything"]')
-    await page.fill('textarea[placeholder="Ask DotCraft anything"]', testMessage)
+    await page.click('textarea[placeholder="Ask DotCraft anything…"]')
+    await page.fill('textarea[placeholder="Ask DotCraft anything…"]', testMessage)
     await screenshot('message-typed')
 
     // ── Step 6: Send ──────────────────────────────────────────────────────

--- a/desktop/src/main/WireProtocolClient.ts
+++ b/desktop/src/main/WireProtocolClient.ts
@@ -18,6 +18,7 @@ export interface ServerCapabilities {
   configOverride?: boolean
   cronManagement?: boolean
   heartbeatManagement?: boolean
+  modelCatalogManagement?: boolean
 }
 
 export interface InitializeResult {
@@ -346,6 +347,10 @@ export class WireProtocolClient extends EventEmitter {
 
   async sendNotification(method: string, params?: unknown): Promise<void> {
     await this.transport.writeLine(JSON.stringify({ jsonrpc: '2.0', method, params }))
+  }
+
+  async listModels(timeoutMs = 20_000): Promise<unknown> {
+    return this.sendRequest('model/list', {}, timeoutMs)
   }
 
   onNotification(callback: NotificationCallback): () => void {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -194,8 +194,14 @@ function registerDesktopIpcHandlers(
     unregisterIpcHandlers()
     ipcHandlersRegistered = false
   }
-  registerIpcHandlers(null, getWireClient, workspacePath, buildCallbacks())
-  ipcHandlersRegistered = true
+  try {
+    registerIpcHandlers(null, getWireClient, workspacePath, buildCallbacks())
+    ipcHandlersRegistered = true
+  } catch (err) {
+    ipcHandlersRegistered = false
+    console.error('[desktop] failed to register IPC handlers', err)
+    throw err
+  }
 }
 
 function unregisterDesktopIpcHandlers(): boolean {

--- a/desktop/src/main/ipcBridge.ts
+++ b/desktop/src/main/ipcBridge.ts
@@ -153,9 +153,16 @@ export function registerIpcHandlers(
   callbacks?: IpcHandlerCallbacks
 ): void {
   invalidateFileIndex()
+  const handleSafe = (
+    channel: string,
+    listener: Parameters<typeof ipcMain.handle>[1]
+  ): void => {
+    ipcMain.removeHandler(channel)
+    ipcMain.handle(channel, listener)
+  }
 
   // Renderer -> Main: send a JSON-RPC request to AppServer
-  ipcMain.handle(
+  handleSafe(
     'appserver:send-request',
     async (_event, method: string, params?: unknown, timeoutMs?: number) => {
       const client = getWireClient()
@@ -166,12 +173,20 @@ export function registerIpcHandlers(
     }
   )
 
-  ipcMain.handle('appserver:get-connection-status', () => {
+  handleSafe('appserver:model-list', async () => {
+    const client = getWireClient()
+    if (!client) {
+      throw new Error(translate(mainLocale(callbacks), 'ipc.appServerNotConnected'))
+    }
+    return client.sendRequest('model/list', {}, 20_000)
+  })
+
+  handleSafe('appserver:get-connection-status', () => {
     return callbacks?.getConnectionStatus() ?? { status: 'disconnected' }
   })
 
   // Renderer -> Main: send back the user's decision for a server-initiated request
-  ipcMain.handle('appserver:server-response', (_event, bridgeId: string, result: unknown) => {
+  handleSafe('appserver:server-response', (_event, bridgeId: string, result: unknown) => {
     const resolve = pendingServerRequests.get(bridgeId)
     if (resolve) {
       pendingServerRequests.delete(bridgeId)
@@ -180,13 +195,13 @@ export function registerIpcHandlers(
   })
 
   // Renderer -> Main: set window title (targets the sender's own window)
-  ipcMain.handle('window:set-title', (event, title: string) => {
+  handleSafe('window:set-title', (event, title: string) => {
     const win = BrowserWindow.fromWebContents(event.sender)
     win?.setTitle(title)
   })
 
   // Renderer -> Main: sync titleBarOverlay colors with app theme (Windows / Linux only)
-  ipcMain.handle('window:set-title-bar-overlay-theme', (event, theme: 'dark' | 'light') => {
+  handleSafe('window:set-title-bar-overlay-theme', (event, theme: 'dark' | 'light') => {
     if (process.platform === 'darwin') return
     const win = BrowserWindow.fromWebContents(event.sender)
     if (!win || win.isDestroyed()) return
@@ -200,15 +215,15 @@ export function registerIpcHandlers(
   })
 
   // Renderer -> Main: get workspace path
-  ipcMain.handle('window:get-workspace-path', () => workspacePath)
+  handleSafe('window:get-workspace-path', () => workspacePath)
 
   // Renderer -> Main: open http(s) URL in the system browser (DashBoard, etc.)
-  ipcMain.handle('shell:open-external', async (_event, url: string) => {
+  handleSafe('shell:open-external', async (_event, url: string) => {
     await openExternalHttpUrl(url)
   })
 
   // Renderer -> Main: write a file to disk (used for revert/re-apply)
-  ipcMain.handle('file:write', async (_event, absPath: string, content: string) => {
+  handleSafe('file:write', async (_event, absPath: string, content: string) => {
     // Security: ensure path is within workspace
     const resolved = path.resolve(absPath)
     const wsResolved = path.resolve(workspacePath)
@@ -221,7 +236,7 @@ export function registerIpcHandlers(
   })
 
   // Renderer -> Main: read a file from disk (used for cumulative diff computation)
-  ipcMain.handle('file:read', async (_event, absPath: string): Promise<string> => {
+  handleSafe('file:read', async (_event, absPath: string): Promise<string> => {
     const resolved = path.resolve(absPath)
     const wsResolved = path.resolve(workspacePath)
     if (!resolved.startsWith(wsResolved + path.sep) && resolved !== wsResolved) {
@@ -239,7 +254,7 @@ export function registerIpcHandlers(
   })
 
   // Renderer -> Main: delete a file (used for reverting new files)
-  ipcMain.handle('file:delete', async (_event, absPath: string) => {
+  handleSafe('file:delete', async (_event, absPath: string) => {
     const resolved = path.resolve(absPath)
     const wsResolved = path.resolve(workspacePath)
     if (!resolved.startsWith(wsResolved + path.sep) && resolved !== wsResolved) {
@@ -251,7 +266,7 @@ export function registerIpcHandlers(
   })
 
   // Renderer -> Main: git add + commit
-  ipcMain.handle(
+  handleSafe(
     'git:commit',
     (_event, wsPath: string, files: string[], message: string): Promise<string> => {
       return new Promise((resolve, reject) => {
@@ -285,7 +300,7 @@ export function registerIpcHandlers(
   // ─── Workspace management ──────────────────────────────────────────────────
 
   // Renderer -> Main: open native folder picker dialog
-  ipcMain.handle('workspace:pick-folder', async (_event) => {
+  handleSafe('workspace:pick-folder', async (_event) => {
     const focusedWin = BrowserWindow.getFocusedWindow()
     const result = await dialog.showOpenDialog(
       focusedWin ?? BrowserWindow.getAllWindows()[0],
@@ -299,29 +314,29 @@ export function registerIpcHandlers(
   })
 
   // Renderer -> Main: switch to a different workspace
-  ipcMain.handle('workspace:switch', async (_event, newPath: string) => {
+  handleSafe('workspace:switch', async (_event, newPath: string) => {
     if (callbacks?.onSwitchWorkspace) {
       await callbacks.onSwitchWorkspace(newPath)
     }
   })
 
   // Renderer -> Main: get recent workspaces
-  ipcMain.handle('workspace:get-recent', () => {
+  handleSafe('workspace:get-recent', () => {
     return callbacks?.getRecentWorkspaces() ?? []
   })
 
   // Renderer -> Main: open a new independent window
-  ipcMain.handle('workspace:open-new-window', () => {
+  handleSafe('workspace:open-new-window', () => {
     callbacks?.onOpenNewWindow()
   })
 
   // Renderer -> Main: check if a workspace is already locked by another process
-  ipcMain.handle('workspace:check-lock', (_event, wsPath: string) => {
+  handleSafe('workspace:check-lock', (_event, wsPath: string) => {
     return checkWorkspaceLock(wsPath)
   })
 
   // Renderer -> Main: save clipboard/drag image bytes to .craft/tmp/images for localImage wire part
-  ipcMain.handle(
+  handleSafe(
     'workspace:save-image-to-temp',
     async (_event, params: { dataUrl: string; fileName?: string }) => {
       const ws = workspacePath
@@ -335,7 +350,7 @@ export function registerIpcHandlers(
   )
 
   // Renderer -> Main: fuzzy file name search for @ mentions
-  ipcMain.handle(
+  handleSafe(
     'workspace:search-files',
     async (
       _event,
@@ -358,12 +373,12 @@ export function registerIpcHandlers(
   // ─── Settings ──────────────────────────────────────────────────────────────
 
   // Renderer -> Main: get current settings
-  ipcMain.handle('settings:get', () => {
+  handleSafe('settings:get', () => {
     return callbacks?.getSettings() ?? {}
   })
 
   // Renderer -> Main: merge + persist partial settings update
-  ipcMain.handle(
+  handleSafe(
     'settings:set',
     (_event, partial: Partial<AppSettings>) => {
       callbacks?.updateSettings(partial)
@@ -448,6 +463,7 @@ export function broadcastServerRequest(
  */
 export function unregisterIpcHandlers(): void {
   ipcMain.removeHandler('appserver:send-request')
+  ipcMain.removeHandler('appserver:model-list')
   ipcMain.removeHandler('appserver:get-connection-status')
   ipcMain.removeHandler('appserver:server-response')
   ipcMain.removeHandler('window:set-title')

--- a/desktop/src/preload/api.d.ts
+++ b/desktop/src/preload/api.d.ts
@@ -40,6 +40,7 @@ declare global {
       }
       appServer: {
         sendRequest(method: string, params?: unknown, timeoutMs?: number): Promise<unknown>
+        listModels(): Promise<unknown>
         getConnectionStatus(): Promise<ConnectionStatusPayload>
         onNotification(callback: (payload: NotificationPayload) => void): UnsubscribeFn
         onConnectionStatus(

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -105,6 +105,10 @@ const api = {
       return ipcRenderer.invoke('appserver:send-request', method, params, timeoutMs)
     },
 
+    listModels(): Promise<unknown> {
+      return ipcRenderer.invoke('appserver:model-list')
+    },
+
     /**
      * Returns the latest connection status snapshot from Main Process.
      * This avoids missing early status events during renderer bootstrap.

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -740,7 +740,7 @@ export function App(): JSX.Element {
       performance.mark(`app:thread-switch-start:${requestedId}`)
       window.api.appServer
         .sendRequest('thread/read', { threadId: curr, includeTurns: true })
-        .then((result) => {
+        .then(async (result) => {
           // Stale guard: user may have switched threads while we were loading
           if (useThreadStore.getState().activeThreadId !== requestedId) {
             useUIStore.getState().cancelPendingWelcomeTurnForThread(requestedId)
@@ -791,13 +791,17 @@ export function App(): JSX.Element {
               }
               setCaseInsensitiveField(existingConfig, 'mode', welcomeMode)
               setCaseInsensitiveField(existingConfig, 'model', welcomeModel)
-              void window.api.appServer
-                .sendRequest('thread/config/update', { threadId, config: existingConfig })
-                .catch((configErr: unknown) => console.error('thread/config/update (welcome model) failed:', configErr))
+              try {
+                await window.api.appServer.sendRequest('thread/config/update', { threadId, config: existingConfig })
+              } catch (configErr: unknown) {
+                console.error('thread/config/update (welcome model) failed:', configErr)
+              }
             } else if (welcomeMode !== 'agent') {
-              void window.api.appServer
-                .sendRequest('thread/mode/set', { threadId, mode: welcomeMode })
-                .catch((modeErr: unknown) => console.error('thread/mode/set (welcome) failed:', modeErr))
+              try {
+                await window.api.appServer.sendRequest('thread/mode/set', { threadId, mode: welcomeMode })
+              } catch (modeErr: unknown) {
+                console.error('thread/mode/set (welcome) failed:', modeErr)
+              }
             }
             const threadEntry = useThreadStore.getState().threadList.find((t) => t.id === threadId)
             if (!threadEntry?.displayName) {

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import { useAutomationsStore } from './stores/automationsStore'
 import { useCronStore, type CronJobWire } from './stores/cronStore'
 import { useReviewPanelStore } from './stores/reviewPanelStore'
 import type { AutomationTask } from './stores/automationsStore'
+import { useModelCatalogStore } from './stores/modelCatalogStore'
 import { CustomMenuBar } from './components/layout/CustomMenuBar'
 import { Sidebar } from './components/layout/Sidebar'
 import { ConversationPanel } from './components/layout/ConversationPanel'
@@ -77,6 +78,7 @@ export function App(): JSX.Element {
   const [workspacePath, setWorkspacePath] = useState('')
   const [workspaceName, setWorkspaceName] = useState('DotCraft')
   const { status, errorType, errorMessage } = useConnectionStore()
+  const capabilities = useConnectionStore((s) => s.capabilities)
   const [showSlowConnectingHint, setShowSlowConnectingHint] = useState(false)
   const activeMainView = useUIStore((s) => s.activeMainView)
   const {
@@ -196,6 +198,7 @@ export function App(): JSX.Element {
     if (status === 'disconnected' || status === 'error') {
       useThreadStore.getState().reset()
       useConversationStore.getState().reset()
+      useModelCatalogStore.getState().reset()
       useCronStore.getState().reset()
       useAutomationsStore.getState().selectTask(null)
       useUIStore.getState().setAutomationsTab('tasks')
@@ -217,6 +220,16 @@ export function App(): JSX.Element {
     }
     prevStatusRef.current = status
   }, [status, reloadThreadList])
+
+  useEffect(() => {
+    if (status === 'connected' && capabilities?.modelCatalogManagement === true) {
+      void useModelCatalogStore.getState().loadIfNeeded()
+      return
+    }
+    if (status === 'disconnected' || status === 'error') {
+      useModelCatalogStore.getState().reset()
+    }
+  }, [capabilities?.modelCatalogManagement, status])
 
   // -------------------------------------------------------------------------
   // Wire protocol notifications

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -785,7 +785,10 @@ export function App(): JSX.Element {
             const pendingText = pendingWelcome.text.trim()
             const pendingImages = pendingWelcome.images
             const welcomeMode = pendingWelcome.mode ?? 'agent'
-            const welcomeModel = typeof pendingWelcome.model === 'string' ? pendingWelcome.model.trim() : ''
+            const rawWelcomeModel =
+              typeof pendingWelcome.model === 'string' ? pendingWelcome.model.trim() : ''
+            const welcomeModel =
+              rawWelcomeModel !== '' && rawWelcomeModel !== 'Default' ? rawWelcomeModel : ''
             useConversationStore.getState().setThreadMode(welcomeMode)
             if (welcomeModel.length > 0) {
               const existingConfig =

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -772,8 +772,29 @@ export function App(): JSX.Element {
             const pendingText = pendingWelcome.text.trim()
             const pendingImages = pendingWelcome.images
             const welcomeMode = pendingWelcome.mode ?? 'agent'
+            const welcomeModel = typeof pendingWelcome.model === 'string' ? pendingWelcome.model.trim() : ''
             useConversationStore.getState().setThreadMode(welcomeMode)
-            if (welcomeMode !== 'agent') {
+            if (welcomeModel.length > 0) {
+              const existingConfig =
+                res.thread.configuration && typeof res.thread.configuration === 'object'
+                  ? { ...(res.thread.configuration as Record<string, unknown>) }
+                  : {}
+              const setCaseInsensitiveField = (
+                target: Record<string, unknown>,
+                key: string,
+                value: unknown
+              ): void => {
+                const lower = key.toLowerCase()
+                const existingKey = Object.keys(target).find((k) => k.toLowerCase() === lower)
+                if (existingKey) target[existingKey] = value
+                else target[key] = value
+              }
+              setCaseInsensitiveField(existingConfig, 'mode', welcomeMode)
+              setCaseInsensitiveField(existingConfig, 'model', welcomeModel)
+              void window.api.appServer
+                .sendRequest('thread/config/update', { threadId, config: existingConfig })
+                .catch((configErr: unknown) => console.error('thread/config/update (welcome model) failed:', configErr))
+            } else if (welcomeMode !== 'agent') {
               void window.api.appServer
                 .sendRequest('thread/mode/set', { threadId, mode: welcomeMode })
                 .catch((modeErr: unknown) => console.error('thread/mode/set (welcome) failed:', modeErr))

--- a/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
+++ b/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
@@ -86,9 +86,10 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
 
   const resolveModelFromConfig = useCallback((cfg: Record<string, unknown>): string => {
     const modelRaw = cfg.Model ?? cfg.model
-    return typeof modelRaw === 'string' && modelRaw.trim().length > 0
-      ? modelRaw
-      : 'Default'
+    if (typeof modelRaw !== 'string') return 'Default'
+    const trimmed = modelRaw.trim()
+    if (trimmed.length === 0 || trimmed === 'Default') return 'Default'
+    return trimmed
   }, [])
 
   const setCaseInsensitiveField = useCallback(
@@ -100,6 +101,12 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
     },
     []
   )
+
+  const deleteCaseInsensitiveField = useCallback((target: Record<string, unknown>, key: string): void => {
+    const lower = key.toLowerCase()
+    const existingKey = Object.keys(target).find((k) => k.toLowerCase() === lower)
+    if (existingKey) delete target[existingKey]
+  }, [])
 
   const suggestions: Suggestion[] = useMemo(
     () => [
@@ -188,7 +195,11 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
       setModelName(nextModel)
       try {
         const cfg = await readWorkspaceConfig()
-        setCaseInsensitiveField(cfg, 'Model', nextModel)
+        if (nextModel === 'Default') {
+          deleteCaseInsensitiveField(cfg, 'Model')
+        } else {
+          setCaseInsensitiveField(cfg, 'Model', nextModel)
+        }
         await window.api.file.writeFile(workspaceConfigPath, `${JSON.stringify(cfg, null, 2)}\n`)
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
@@ -198,7 +209,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
         setModelApplying(false)
       }
     },
-    [modelName, readWorkspaceConfig, setCaseInsensitiveField, workspaceConfigPath]
+    [deleteCaseInsensitiveField, modelName, readWorkspaceConfig, setCaseInsensitiveField, workspaceConfigPath]
   )
 
   const saveDataUrlAsTemp = useCallback(
@@ -242,7 +253,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
     setStarting(true)
     const capturedImages = [...images]
     const capturedMode = welcomeMode
-    const capturedModel = modelName
+    const capturedModel = modelName === 'Default' ? '' : modelName
     try {
       const res = await window.api.appServer.sendRequest('thread/start', {
         identity: {

--- a/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
+++ b/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
@@ -53,9 +53,13 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
   /** Agent/plan before a thread exists; applied when the first thread is created. */
   const [welcomeMode, setWelcomeMode] = useState<ThreadMode>('agent')
   const [modelName, setModelName] = useState<string>('Default')
+  const [modelOptions, setModelOptions] = useState<string[]>([])
+  const [modelLoading, setModelLoading] = useState(false)
+  const [modelApplying, setModelApplying] = useState(false)
   const sendInFlightRef = useRef(false)
   const richRef = useRef<RichInputAreaHandle>(null)
   const connectionStatus = useConnectionStore((s) => s.status)
+  const capabilities = useConnectionStore((s) => s.capabilities)
   const { addThread, setActiveThreadId } = useThreadStore()
 
   const isConnected = connectionStatus === 'connected'
@@ -67,6 +71,31 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
     const sep = normalized.includes('\\') ? '\\' : '/'
     return `${normalized}${sep}.craft${sep}config.json`
   }, [workspacePath])
+
+  const readWorkspaceConfig = useCallback(async (): Promise<Record<string, unknown>> => {
+    if (!workspaceConfigPath) return {}
+    const raw = await window.api.file.readFile(workspaceConfigPath)
+    if (!raw.trim()) return {}
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  }, [workspaceConfigPath])
+
+  const resolveModelFromConfig = useCallback((cfg: Record<string, unknown>): string => {
+    const modelRaw = cfg.Model ?? cfg.model
+    return typeof modelRaw === 'string' && modelRaw.trim().length > 0
+      ? modelRaw
+      : 'Default'
+  }, [])
+
+  const setCaseInsensitiveField = useCallback(
+    (target: Record<string, unknown>, key: string, value: unknown): void => {
+      const lower = key.toLowerCase()
+      const existingKey = Object.keys(target).find((k) => k.toLowerCase() === lower)
+      if (existingKey) target[existingKey] = value
+      else target[key] = value
+    },
+    []
+  )
 
   const suggestions: Suggestion[] = useMemo(
     () => [
@@ -115,34 +144,86 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
 
   useEffect(() => {
     let disposed = false
-    const loadModelName = async (): Promise<void> => {
+    const loadModelState = async (): Promise<void> => {
       if (!workspaceConfigPath) {
         setModelName('Default')
+        setModelOptions([])
         return
       }
+
       try {
-        const raw = await window.api.file.readFile(workspaceConfigPath)
+        const cfg = await readWorkspaceConfig()
         if (disposed) return
-        if (!raw.trim()) {
-          setModelName('Default')
-          return
-        }
-        const cfg = JSON.parse(raw) as Record<string, unknown>
-        const modelRaw = cfg.Model ?? cfg.model
-        const model = typeof modelRaw === 'string' && modelRaw.trim().length > 0
-          ? modelRaw
-          : 'Default'
-        setModelName(model)
+        setModelName(resolveModelFromConfig(cfg))
       } catch {
         if (!disposed) setModelName('Default')
       }
+
+      const canListModels =
+        isConnected &&
+        capabilities?.modelCatalogManagement === true
+      if (!canListModels) {
+        if (!disposed) setModelOptions([])
+        return
+      }
+
+      setModelLoading(true)
+      try {
+        const result = await window.api.appServer.listModels()
+        if (disposed) return
+        const typed = result as {
+          success?: boolean
+          models?: Array<{ id?: string; Id?: string }>
+        }
+        const options = typed.success && Array.isArray(typed.models)
+          ? typed.models.map((m) => String(m.id ?? m.Id ?? '').trim()).filter(Boolean)
+          : []
+        setModelOptions(Array.from(new Set(options)).sort((a, b) => a.localeCompare(b)))
+      } catch {
+        if (!disposed) setModelOptions([])
+      } finally {
+        if (!disposed) setModelLoading(false)
+      }
     }
 
-    void loadModelName()
+    void loadModelState()
     return () => {
       disposed = true
     }
-  }, [workspaceConfigPath])
+  }, [
+    capabilities?.modelCatalogManagement,
+    isConnected,
+    readWorkspaceConfig,
+    resolveModelFromConfig,
+    workspaceConfigPath
+  ])
+
+  const effectiveModelOptions = useMemo(() => {
+    if (!modelName || modelName === 'Default') return modelOptions
+    if (modelOptions.includes(modelName)) return modelOptions
+    return [modelName, ...modelOptions]
+  }, [modelName, modelOptions])
+
+  const handleModelChange = useCallback(
+    async (nextModel: string): Promise<void> => {
+      if (!workspaceConfigPath || !nextModel || nextModel === modelName) return
+      setModelApplying(true)
+      const previousModel = modelName
+      setModelName(nextModel)
+      try {
+        const cfg = await readWorkspaceConfig()
+        setCaseInsensitiveField(cfg, 'Model', nextModel)
+        await window.api.file.writeFile(workspaceConfigPath, `${JSON.stringify(cfg, null, 2)}\n`)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        setModelName(previousModel)
+        addToast(`Failed to save model: ${msg}`, 'error')
+      } finally {
+        setModelApplying(false)
+      }
+    },
+    [modelName, readWorkspaceConfig, setCaseInsensitiveField, workspaceConfigPath]
+  )
 
   const saveDataUrlAsTemp = useCallback(
     async (dataUrl: string, fileName: string, mimeType: string): Promise<void> => {
@@ -184,6 +265,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
     setStarting(true)
     const capturedImages = [...images]
     const capturedMode = welcomeMode
+    const capturedModel = modelName
     try {
       const res = await window.api.appServer.sendRequest('thread/start', {
         identity: {
@@ -199,7 +281,8 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
         threadId: res.thread.id,
         text: trimmed,
         images: capturedImages.length > 0 ? capturedImages : undefined,
-        mode: capturedMode
+        mode: capturedMode,
+        model: capturedModel
       })
       addThread(res.thread)
       setActiveThreadId(res.thread.id)
@@ -212,7 +295,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
       sendInFlightRef.current = false
       setStarting(false)
     }
-  }, [images, connectionStatus, workspacePath, addThread, setActiveThreadId, welcomeMode])
+  }, [images, connectionStatus, workspacePath, addThread, setActiveThreadId, welcomeMode, modelName])
 
   const onPasteImage = useCallback(
     (file: File): void => {
@@ -547,9 +630,42 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
 
             <span style={{ color: 'var(--border-default)' }}>·</span>
 
-            <span style={{ fontSize: '12px', color: 'var(--text-dimmed)' }}>
-              {modelName === 'Default' ? t('composer.defaultModel') : modelName}
-            </span>
+            {effectiveModelOptions.length > 0 ? (
+              <select
+                value={modelName}
+                disabled={modelLoading || modelApplying || starting}
+                onChange={(e) => {
+                  void handleModelChange(e.target.value)
+                }}
+                title={modelLoading ? 'Loading models...' : 'Select model'}
+                style={{
+                  fontSize: '12px',
+                  color: (modelApplying || starting) ? 'var(--text-dimmed)' : 'var(--text-primary)',
+                  backgroundColor: 'var(--bg-secondary)',
+                  border: '1px solid var(--border-default)',
+                  borderRadius: '6px',
+                  padding: '2px 6px',
+                  minHeight: '22px',
+                  maxWidth: '220px',
+                  outline: 'none',
+                  cursor: (modelApplying || starting) ? 'default' : 'pointer'
+                }}
+              >
+                {effectiveModelOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt === 'Default' ? t('composer.defaultModel') : opt}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <span style={{ fontSize: '12px', color: 'var(--text-dimmed)' }}>
+                {modelLoading
+                  ? 'Loading models...'
+                  : modelName === 'Default'
+                    ? t('composer.defaultModel')
+                    : modelName}
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
+++ b/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
@@ -52,6 +52,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
   const [mentionDismissed, setMentionDismissed] = useState(false)
   /** Agent/plan before a thread exists; applied when the first thread is created. */
   const [welcomeMode, setWelcomeMode] = useState<ThreadMode>('agent')
+  const [modelName, setModelName] = useState<string>('Default')
   const sendInFlightRef = useRef(false)
   const richRef = useRef<RichInputAreaHandle>(null)
   const connectionStatus = useConnectionStore((s) => s.status)
@@ -60,6 +61,12 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
   const isConnected = connectionStatus === 'connected'
   const busy = starting || !isConnected
   const showMentionPopover = atQuery !== null && !mentionDismissed
+  const workspaceConfigPath = useMemo(() => {
+    if (!workspacePath) return ''
+    const normalized = workspacePath.replace(/[\\/]+$/, '')
+    const sep = normalized.includes('\\') ? '\\' : '/'
+    return `${normalized}${sep}.craft${sep}config.json`
+  }, [workspacePath])
 
   const suggestions: Suggestion[] = useMemo(
     () => [
@@ -105,6 +112,37 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
       richRef.current?.focus()
     }
   }, [isConnected])
+
+  useEffect(() => {
+    let disposed = false
+    const loadModelName = async (): Promise<void> => {
+      if (!workspaceConfigPath) {
+        setModelName('Default')
+        return
+      }
+      try {
+        const raw = await window.api.file.readFile(workspaceConfigPath)
+        if (disposed) return
+        if (!raw.trim()) {
+          setModelName('Default')
+          return
+        }
+        const cfg = JSON.parse(raw) as Record<string, unknown>
+        const modelRaw = cfg.Model ?? cfg.model
+        const model = typeof modelRaw === 'string' && modelRaw.trim().length > 0
+          ? modelRaw
+          : 'Default'
+        setModelName(model)
+      } catch {
+        if (!disposed) setModelName('Default')
+      }
+    }
+
+    void loadModelName()
+    return () => {
+      disposed = true
+    }
+  }, [workspaceConfigPath])
 
   const saveDataUrlAsTemp = useCallback(
     async (dataUrl: string, fileName: string, mimeType: string): Promise<void> => {
@@ -510,7 +548,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
             <span style={{ color: 'var(--border-default)' }}>·</span>
 
             <span style={{ fontSize: '12px', color: 'var(--text-dimmed)' }}>
-              {t('composer.defaultModel')}
+              {modelName === 'Default' ? t('composer.defaultModel') : modelName}
             </span>
           </div>
         </div>

--- a/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
+++ b/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
@@ -232,7 +232,8 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
     if (
       (!trimmed && images.length === 0) ||
       sendInFlightRef.current ||
-      connectionStatus !== 'connected'
+      connectionStatus !== 'connected' ||
+      modelLoading
     ) {
       return
     }
@@ -271,7 +272,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
       sendInFlightRef.current = false
       setStarting(false)
     }
-  }, [images, connectionStatus, workspacePath, addThread, setActiveThreadId, welcomeMode, modelName])
+  }, [images, connectionStatus, workspacePath, addThread, setActiveThreadId, welcomeMode, modelName, modelLoading])
 
   const onPasteImage = useCallback(
     (file: File): void => {
@@ -331,8 +332,8 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
 
   const canSend = useMemo(() => {
     const textLen = (richRef.current?.getText() ?? '').trim().length
-    return (textLen > 0 || images.length > 0) && isConnected && !starting
-  }, [contentRevision, images.length, isConnected, starting])
+    return (textLen > 0 || images.length > 0) && isConnected && !starting && !modelLoading
+  }, [contentRevision, images.length, isConnected, starting, modelLoading])
 
   return (
     <div
@@ -511,7 +512,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
               <RichInputArea
                 ref={richRef}
                 disabled={busy}
-                suppressSubmit={showMentionPopover}
+                suppressSubmit={showMentionPopover || modelLoading}
                 placeholder={
                   isConnected
                     ? t('welcomeComposer.placeholder.ask')
@@ -608,14 +609,33 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
 
             <span style={{ color: 'var(--border-default)' }}>·</span>
 
-            {(effectiveModelOptions.length > 0 || modelLoading) ? (
+            {modelLoading ? (
+              <span
+                role="status"
+                aria-live="polite"
+                style={{
+                  fontSize: '12px',
+                  color: 'var(--text-dimmed)',
+                  display: 'inline-block',
+                  width: '170px',
+                  minWidth: '170px',
+                  maxWidth: '170px',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis'
+                }}
+                title={t('composer.modelListLoading')}
+              >
+                {t('composer.modelListLoading')}
+              </span>
+            ) : effectiveModelOptions.length > 0 ? (
               <select
                 value={modelName}
-                disabled={modelLoading || modelApplying || starting}
+                disabled={modelApplying || starting}
                 onChange={(e) => {
                   void handleModelChange(e.target.value)
                 }}
-                title={modelLoading ? t('composer.modelListLoading') : t('composer.selectModelTitle')}
+                title={t('composer.selectModelTitle')}
                 style={{
                   fontSize: '12px',
                   color: (modelApplying || starting) ? 'var(--text-dimmed)' : 'var(--text-primary)',
@@ -628,14 +648,10 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
                   minWidth: '170px',
                   maxWidth: '170px',
                   outline: 'none',
-                  cursor: (modelLoading || modelApplying || starting) ? 'default' : 'pointer'
+                  cursor: (modelApplying || starting) ? 'default' : 'pointer'
                 }}
               >
-                {modelLoading ? (
-                  <option value={modelName}>
-                    {t('composer.modelListLoading')}
-                  </option>
-                ) : effectiveModelOptions.map((opt) => (
+                {effectiveModelOptions.map((opt) => (
                   <option key={opt} value={opt}>
                     {opt === 'Default' ? t('composer.defaultModel') : opt}
                   </option>

--- a/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
+++ b/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
@@ -182,9 +182,10 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
 
   const effectiveModelOptions = useMemo(() => {
     const sourceOptions = modelApiAvailable ? modelOptions : []
-    if (!modelName || modelName === 'Default') return sourceOptions
-    if (sourceOptions.includes(modelName)) return sourceOptions
-    return [modelName, ...sourceOptions]
+    const withDefault = ['Default', ...sourceOptions.filter((o) => o !== 'Default')]
+    if (!modelName || modelName === 'Default') return withDefault
+    if (withDefault.includes(modelName)) return withDefault
+    return [modelName, ...withDefault]
   }, [modelApiAvailable, modelName, modelOptions])
 
   const handleModelChange = useCallback(

--- a/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
+++ b/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
@@ -454,15 +454,17 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
         />
       </div>
 
-      {/* Bottom composer */}
+      {/* Bottom composer — same width/padding as InputComposer (full panel width, no max-width cap) */}
       <div
         style={{
           flexShrink: 0,
           padding: '14px 14px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '6px',
           opacity: starting ? 0.65 : 1
         }}
       >
-        <div style={{ maxWidth: '720px', margin: '0 auto', display: 'flex', flexDirection: 'column', gap: '6px' }}>
           <div
             style={{ position: 'relative' }}
             onDragOver={onDragOver}
@@ -495,7 +497,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
                 setImages((prev) => prev.filter((_, i) => i !== idx))
               }}
             />
-            <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px' }}>
+            <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px', position: 'relative' }}>
             <div style={{ flex: 1, position: 'relative', minWidth: 0 }}>
               <FileSearchPopover
                 query={atQuery ?? ''}
@@ -660,7 +662,6 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
               </span>
             )}
           </div>
-        </div>
       </div>
     </div>
   )

--- a/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
+++ b/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
@@ -2,10 +2,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useT } from '../../contexts/LocaleContext'
 import { DotCraftLogo } from '../ui/DotCraftLogo'
 import { useConnectionStore } from '../../stores/connectionStore'
+import { useModelCatalogStore } from '../../stores/modelCatalogStore'
 import { useThreadStore } from '../../stores/threadStore'
 import { useUIStore } from '../../stores/uiStore'
 import { addToast } from '../../stores/toastStore'
 import type { ImageAttachment, ThreadMode } from '../../types/conversation'
+import type { ThreadSummary } from '../../types/thread'
 import { FileSearchPopover } from './FileSearchPopover'
 import { ImageStrip } from './ImageStrip'
 import { RichInputArea, type RichInputAreaHandle } from './RichInputArea'
@@ -53,18 +55,20 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
   /** Agent/plan before a thread exists; applied when the first thread is created. */
   const [welcomeMode, setWelcomeMode] = useState<ThreadMode>('agent')
   const [modelName, setModelName] = useState<string>('Default')
-  const [modelOptions, setModelOptions] = useState<string[]>([])
-  const [modelLoading, setModelLoading] = useState(false)
   const [modelApplying, setModelApplying] = useState(false)
   const sendInFlightRef = useRef(false)
   const richRef = useRef<RichInputAreaHandle>(null)
   const connectionStatus = useConnectionStore((s) => s.status)
   const capabilities = useConnectionStore((s) => s.capabilities)
+  const modelOptions = useModelCatalogStore((s) => s.modelOptions)
+  const modelCatalogStatus = useModelCatalogStore((s) => s.status)
   const { addThread, setActiveThreadId } = useThreadStore()
 
   const isConnected = connectionStatus === 'connected'
   const busy = starting || !isConnected
   const showMentionPopover = atQuery !== null && !mentionDismissed
+  const modelApiAvailable = isConnected && capabilities?.modelCatalogManagement === true
+  const modelLoading = modelApiAvailable && modelCatalogStatus === 'loading'
   const workspaceConfigPath = useMemo(() => {
     if (!workspacePath) return ''
     const normalized = workspacePath.replace(/[\\/]+$/, '')
@@ -144,10 +148,9 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
 
   useEffect(() => {
     let disposed = false
-    const loadModelState = async (): Promise<void> => {
+    const loadModelName = async (): Promise<void> => {
       if (!workspaceConfigPath) {
         setModelName('Default')
-        setModelOptions([])
         return
       }
 
@@ -158,51 +161,24 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
       } catch {
         if (!disposed) setModelName('Default')
       }
-
-      const canListModels =
-        isConnected &&
-        capabilities?.modelCatalogManagement === true
-      if (!canListModels) {
-        if (!disposed) setModelOptions([])
-        return
-      }
-
-      setModelLoading(true)
-      try {
-        const result = await window.api.appServer.listModels()
-        if (disposed) return
-        const typed = result as {
-          success?: boolean
-          models?: Array<{ id?: string; Id?: string }>
-        }
-        const options = typed.success && Array.isArray(typed.models)
-          ? typed.models.map((m) => String(m.id ?? m.Id ?? '').trim()).filter(Boolean)
-          : []
-        setModelOptions(Array.from(new Set(options)).sort((a, b) => a.localeCompare(b)))
-      } catch {
-        if (!disposed) setModelOptions([])
-      } finally {
-        if (!disposed) setModelLoading(false)
-      }
     }
 
-    void loadModelState()
+    void loadModelName()
     return () => {
       disposed = true
     }
   }, [
-    capabilities?.modelCatalogManagement,
-    isConnected,
     readWorkspaceConfig,
     resolveModelFromConfig,
     workspaceConfigPath
   ])
 
   const effectiveModelOptions = useMemo(() => {
-    if (!modelName || modelName === 'Default') return modelOptions
-    if (modelOptions.includes(modelName)) return modelOptions
-    return [modelName, ...modelOptions]
-  }, [modelName, modelOptions])
+    const sourceOptions = modelApiAvailable ? modelOptions : []
+    if (!modelName || modelName === 'Default') return sourceOptions
+    if (sourceOptions.includes(modelName)) return sourceOptions
+    return [modelName, ...sourceOptions]
+  }, [modelApiAvailable, modelName, modelOptions])
 
   const handleModelChange = useCallback(
     async (nextModel: string): Promise<void> => {
@@ -275,7 +251,7 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
           workspacePath
         },
         historyMode: 'server'
-      }) as { thread: { id: string; displayName?: string | null; status?: string; createdAt?: string } }
+      }) as { thread: ThreadSummary }
 
       useUIStore.getState().setPendingWelcomeTurn({
         threadId: res.thread.id,
@@ -630,14 +606,14 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
 
             <span style={{ color: 'var(--border-default)' }}>·</span>
 
-            {effectiveModelOptions.length > 0 ? (
+            {(effectiveModelOptions.length > 0 || modelLoading) ? (
               <select
                 value={modelName}
                 disabled={modelLoading || modelApplying || starting}
                 onChange={(e) => {
                   void handleModelChange(e.target.value)
                 }}
-                title={modelLoading ? 'Loading models...' : 'Select model'}
+                title={modelLoading ? t('composer.modelListLoading') : t('composer.selectModelTitle')}
                 style={{
                   fontSize: '12px',
                   color: (modelApplying || starting) ? 'var(--text-dimmed)' : 'var(--text-primary)',
@@ -646,24 +622,41 @@ export function ConversationWelcome({ workspacePath }: ConversationWelcomeProps)
                   borderRadius: '6px',
                   padding: '2px 6px',
                   minHeight: '22px',
-                  maxWidth: '220px',
+                  width: '170px',
+                  minWidth: '170px',
+                  maxWidth: '170px',
                   outline: 'none',
-                  cursor: (modelApplying || starting) ? 'default' : 'pointer'
+                  cursor: (modelLoading || modelApplying || starting) ? 'default' : 'pointer'
                 }}
               >
-                {effectiveModelOptions.map((opt) => (
+                {modelLoading ? (
+                  <option value={modelName}>
+                    {t('composer.modelListLoading')}
+                  </option>
+                ) : effectiveModelOptions.map((opt) => (
                   <option key={opt} value={opt}>
                     {opt === 'Default' ? t('composer.defaultModel') : opt}
                   </option>
                 ))}
               </select>
             ) : (
-              <span style={{ fontSize: '12px', color: 'var(--text-dimmed)' }}>
-                {modelLoading
-                  ? 'Loading models...'
-                  : modelName === 'Default'
-                    ? t('composer.defaultModel')
-                    : modelName}
+              <span
+                style={{
+                  fontSize: '12px',
+                  color: 'var(--text-dimmed)',
+                  display: 'inline-block',
+                  width: '170px',
+                  minWidth: '170px',
+                  maxWidth: '170px',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis'
+                }}
+                title={modelName === 'Default' ? t('composer.defaultModel') : modelName}
+              >
+                {modelName === 'Default'
+                  ? t('composer.defaultModel')
+                  : modelName}
               </span>
             )}
           </div>

--- a/desktop/src/renderer/components/conversation/InputComposer.tsx
+++ b/desktop/src/renderer/components/conversation/InputComposer.tsx
@@ -204,6 +204,7 @@ export function InputComposer({
     const trimmed = text.trim()
     if (!trimmed && images.length === 0) return
     if (isWaitingApproval) return
+    if (modelLoading) return
 
     if (isRunning) {
       if (images.length > 0) {
@@ -278,7 +279,7 @@ export function InputComposer({
       console.error('turn/start failed:', err)
       useConversationStore.getState().removeOptimisticTurn(optimisticTurnId)
     }
-  }, [images, isRunning, isWaitingApproval, threadId, workspacePath, setPendingMessage, t])
+  }, [images, isRunning, isWaitingApproval, modelLoading, threadId, workspacePath, setPendingMessage, t])
 
   const stopTurn = useCallback(async () => {
     const activeTurnId = useConversationStore.getState().activeTurnId
@@ -305,8 +306,8 @@ export function InputComposer({
 
   const canSend = useMemo(() => {
     const textLen = (richRef.current?.getText() ?? '').trim().length
-    return (textLen > 0 || images.length > 0) && !isWaitingApproval
-  }, [contentRevision, images.length, isWaitingApproval])
+    return (textLen > 0 || images.length > 0) && !isWaitingApproval && !modelLoading
+  }, [contentRevision, images.length, isWaitingApproval, modelLoading])
 
   const effectiveModelOptions = useMemo(() => {
     if (!modelName || modelName === 'Default') return modelOptions
@@ -375,7 +376,7 @@ export function InputComposer({
               <RichInputArea
                 ref={richRef}
                 disabled={isWaitingApproval}
-                suppressSubmit={showMentionPopover}
+                suppressSubmit={showMentionPopover || modelLoading}
                 placeholder={
                   isWaitingApproval ? t('composer.placeholder.approval') : t('composer.placeholder.ask')
                 }
@@ -482,12 +483,31 @@ export function InputComposer({
 
           <span style={{ color: 'var(--border-default)' }}>·</span>
 
-          {(effectiveModelOptions.length > 0 || modelLoading) ? (
+          {modelLoading ? (
+            <span
+              role="status"
+              aria-live="polite"
+              style={{
+                fontSize: '12px',
+                color: 'var(--text-dimmed)',
+                display: 'inline-block',
+                width: '170px',
+                minWidth: '170px',
+                maxWidth: '170px',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis'
+              }}
+              title={t('composer.modelListLoading')}
+            >
+              {t('composer.modelListLoading')}
+            </span>
+          ) : effectiveModelOptions.length > 0 ? (
             <select
               value={modelName}
-              disabled={modelLoading || modelDisabled}
+              disabled={modelDisabled}
               onChange={(e) => onModelChange?.(e.target.value)}
-              title={modelLoading ? t('composer.modelListLoading') : t('composer.selectModelTitle')}
+              title={t('composer.selectModelTitle')}
               style={{
                 fontSize: '12px',
                 color: modelDisabled ? 'var(--text-dimmed)' : 'var(--text-primary)',
@@ -500,14 +520,10 @@ export function InputComposer({
                 minWidth: '170px',
                 maxWidth: '170px',
                 outline: 'none',
-                cursor: (modelDisabled || modelLoading) ? 'default' : 'pointer'
+                cursor: modelDisabled ? 'default' : 'pointer'
               }}
             >
-              {modelLoading ? (
-                <option value={modelName}>
-                  {t('composer.modelListLoading')}
-                </option>
-              ) : effectiveModelOptions.map((opt) => (
+              {effectiveModelOptions.map((opt) => (
                 <option key={opt} value={opt}>
                   {opt === 'Default' ? t('composer.defaultModel') : opt}
                 </option>

--- a/desktop/src/renderer/components/conversation/InputComposer.tsx
+++ b/desktop/src/renderer/components/conversation/InputComposer.tsx
@@ -310,9 +310,10 @@ export function InputComposer({
   }, [contentRevision, images.length, isWaitingApproval, modelLoading])
 
   const effectiveModelOptions = useMemo(() => {
-    if (!modelName || modelName === 'Default') return modelOptions
-    if (modelOptions.includes(modelName)) return modelOptions
-    return [modelName, ...modelOptions]
+    const withDefault = ['Default', ...modelOptions.filter((o) => o !== 'Default')]
+    if (!modelName || modelName === 'Default') return withDefault
+    if (withDefault.includes(modelName)) return withDefault
+    return [modelName, ...withDefault]
   }, [modelName, modelOptions])
 
   const onSelectFile = useCallback(

--- a/desktop/src/renderer/components/conversation/InputComposer.tsx
+++ b/desktop/src/renderer/components/conversation/InputComposer.tsx
@@ -482,12 +482,12 @@ export function InputComposer({
 
           <span style={{ color: 'var(--border-default)' }}>·</span>
 
-          {effectiveModelOptions.length > 0 ? (
+          {(effectiveModelOptions.length > 0 || modelLoading) ? (
             <select
               value={modelName}
               disabled={modelLoading || modelDisabled}
               onChange={(e) => onModelChange?.(e.target.value)}
-              title={modelLoading ? 'Loading models...' : 'Select model'}
+              title={modelLoading ? t('composer.modelListLoading') : t('composer.selectModelTitle')}
               style={{
                 fontSize: '12px',
                 color: modelDisabled ? 'var(--text-dimmed)' : 'var(--text-primary)',
@@ -496,20 +496,39 @@ export function InputComposer({
                 borderRadius: '6px',
                 padding: '2px 6px',
                 minHeight: '22px',
-                maxWidth: '220px',
+                width: '170px',
+                minWidth: '170px',
+                maxWidth: '170px',
                 outline: 'none',
-                cursor: modelDisabled ? 'default' : 'pointer'
+                cursor: (modelDisabled || modelLoading) ? 'default' : 'pointer'
               }}
             >
-              {effectiveModelOptions.map((opt) => (
+              {modelLoading ? (
+                <option value={modelName}>
+                  {t('composer.modelListLoading')}
+                </option>
+              ) : effectiveModelOptions.map((opt) => (
                 <option key={opt} value={opt}>
                   {opt === 'Default' ? t('composer.defaultModel') : opt}
                 </option>
               ))}
             </select>
           ) : (
-            <span style={{ fontSize: '12px', color: 'var(--text-dimmed)' }}>
-              {modelLoading ? 'Loading models...' : modelName === 'Default' ? t('composer.defaultModel') : modelName}
+            <span
+              style={{
+                fontSize: '12px',
+                color: 'var(--text-dimmed)',
+                display: 'inline-block',
+                width: '170px',
+                minWidth: '170px',
+                maxWidth: '170px',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis'
+              }}
+              title={modelName === 'Default' ? t('composer.defaultModel') : modelName}
+            >
+              {modelName === 'Default' ? t('composer.defaultModel') : modelName}
             </span>
           )}
         </div>

--- a/desktop/src/renderer/components/conversation/InputComposer.tsx
+++ b/desktop/src/renderer/components/conversation/InputComposer.tsx
@@ -30,13 +30,25 @@ interface InputComposerProps {
   threadId: string
   workspacePath: string
   modelName?: string
+  modelOptions?: string[]
+  modelLoading?: boolean
+  modelDisabled?: boolean
+  onModelChange?: (model: string) => void
 }
 
 /**
  * Bottom input area for the conversation panel.
  * Rich input with @ file refs, image strip (paste / drag-drop), Enter to send.
  */
-export function InputComposer({ threadId, workspacePath, modelName = 'Default' }: InputComposerProps): JSX.Element {
+export function InputComposer({
+  threadId,
+  workspacePath,
+  modelName = 'Default',
+  modelOptions = [],
+  modelLoading = false,
+  modelDisabled = false,
+  onModelChange
+}: InputComposerProps): JSX.Element {
   const t = useT()
   const [images, setImages] = useState<ImageAttachment[]>([])
   const [atQuery, setAtQuery] = useState<string | null>(null)
@@ -296,6 +308,12 @@ export function InputComposer({ threadId, workspacePath, modelName = 'Default' }
     return (textLen > 0 || images.length > 0) && !isWaitingApproval
   }, [contentRevision, images.length, isWaitingApproval])
 
+  const effectiveModelOptions = useMemo(() => {
+    if (!modelName || modelName === 'Default') return modelOptions
+    if (modelOptions.includes(modelName)) return modelOptions
+    return [modelName, ...modelOptions]
+  }, [modelName, modelOptions])
+
   const onSelectFile = useCallback(
     (relativePath: string): void => {
       richRef.current?.insertFileTag(relativePath)
@@ -464,9 +482,36 @@ export function InputComposer({ threadId, workspacePath, modelName = 'Default' }
 
           <span style={{ color: 'var(--border-default)' }}>·</span>
 
-          <span style={{ fontSize: '12px', color: 'var(--text-dimmed)' }}>
-            {modelName === 'Default' ? t('composer.defaultModel') : modelName}
-          </span>
+          {effectiveModelOptions.length > 0 ? (
+            <select
+              value={modelName}
+              disabled={modelLoading || modelDisabled}
+              onChange={(e) => onModelChange?.(e.target.value)}
+              title={modelLoading ? 'Loading models...' : 'Select model'}
+              style={{
+                fontSize: '12px',
+                color: modelDisabled ? 'var(--text-dimmed)' : 'var(--text-primary)',
+                backgroundColor: 'var(--bg-secondary)',
+                border: '1px solid var(--border-default)',
+                borderRadius: '6px',
+                padding: '2px 6px',
+                minHeight: '22px',
+                maxWidth: '220px',
+                outline: 'none',
+                cursor: modelDisabled ? 'default' : 'pointer'
+              }}
+            >
+              {effectiveModelOptions.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt === 'Default' ? t('composer.defaultModel') : opt}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span style={{ fontSize: '12px', color: 'var(--text-dimmed)' }}>
+              {modelLoading ? 'Loading models...' : modelName === 'Default' ? t('composer.defaultModel') : modelName}
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/desktop/src/renderer/components/conversation/RichInputArea.tsx
+++ b/desktop/src/renderer/components/conversation/RichInputArea.tsx
@@ -12,7 +12,7 @@ import { serializeEditor, truncateEditorDomToSerializedLength } from './richInpu
 
 const MAX_ROWS = 8
 const MAX_TEXT_LEN = 100_000
-const PLACEHOLDER = 'Ask DotCraft anything'
+const PLACEHOLDER = 'Ask DotCraft anything…'
 
 export interface RichInputAreaHandle {
   getText: () => string

--- a/desktop/src/renderer/components/layout/ConversationPanel.tsx
+++ b/desktop/src/renderer/components/layout/ConversationPanel.tsx
@@ -68,16 +68,23 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
     []
   )
 
+  const deleteCaseInsensitiveField = useCallback((target: Record<string, unknown>, key: string): void => {
+    const lower = key.toLowerCase()
+    const existingKey = Object.keys(target).find((k) => k.toLowerCase() === lower)
+    if (existingKey) delete target[existingKey]
+  }, [])
+
   const resolveEffectiveModel = useCallback(
     (thread: typeof activeThread, workspaceCfg: Record<string, unknown>): string => {
       const workspaceModelRaw = workspaceCfg.Model ?? workspaceCfg.model
+      const ws =
+        typeof workspaceModelRaw === 'string' ? workspaceModelRaw.trim() : ''
       const workspaceModel =
-        typeof workspaceModelRaw === 'string' && workspaceModelRaw.trim().length > 0
-          ? workspaceModelRaw
-          : null
-      const modelFromThread = thread?.configuration?.model ?? thread?.configuration?.Model
-      if (typeof modelFromThread === 'string' && modelFromThread.trim()) {
-        return modelFromThread
+        ws.length > 0 && ws !== 'Default' ? ws : null
+      const threadRaw = thread?.configuration?.model ?? thread?.configuration?.Model
+      const threadTrimmed = typeof threadRaw === 'string' ? threadRaw.trim() : ''
+      if (threadTrimmed.length > 0 && threadTrimmed !== 'Default') {
+        return threadTrimmed
       }
       return workspaceModel ?? 'Default'
     },
@@ -94,7 +101,8 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
       } catch {
         if (disposed) return
         const modelFromThread = activeThread?.configuration?.model ?? activeThread?.configuration?.Model
-        setModelName(typeof modelFromThread === 'string' && modelFromThread.trim() ? modelFromThread : 'Default')
+        const mt = typeof modelFromThread === 'string' ? modelFromThread.trim() : ''
+        setModelName(mt.length > 0 && mt !== 'Default' ? mt : 'Default')
       }
     }
 
@@ -118,7 +126,11 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
       setModelName(nextModel)
       try {
         const workspaceCfg = await readWorkspaceConfig()
-        setCaseInsensitiveField(workspaceCfg, 'Model', nextModel)
+        if (nextModel === 'Default') {
+          deleteCaseInsensitiveField(workspaceCfg, 'Model')
+        } else {
+          setCaseInsensitiveField(workspaceCfg, 'Model', nextModel)
+        }
         await window.api.file.writeFile(workspaceConfigPath, `${JSON.stringify(workspaceCfg, null, 2)}\n`)
 
         const readRes = (await window.api.appServer.sendRequest('thread/read', {
@@ -130,7 +142,11 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
             ? { ...(readRes.thread.configuration as Record<string, unknown>) }
             : {}
         setCaseInsensitiveField(existingConfig, 'mode', threadMode)
-        setCaseInsensitiveField(existingConfig, 'model', nextModel)
+        if (nextModel === 'Default') {
+          deleteCaseInsensitiveField(existingConfig, 'model')
+        } else {
+          setCaseInsensitiveField(existingConfig, 'model', nextModel)
+        }
 
         await window.api.appServer.sendRequest('thread/config/update', {
           threadId: activeThread.id,
@@ -138,15 +154,21 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
         })
         const active = useThreadStore.getState().activeThread
         if (active && active.id === activeThread.id) {
+          const mergedCfg: Record<string, unknown> = { ...(active.configuration ?? {}) }
+          if (nextModel === 'Default') {
+            deleteCaseInsensitiveField(mergedCfg, 'model')
+          } else {
+            mergedCfg.model = nextModel
+          }
           useThreadStore.getState().setActiveThread({
             ...active,
-            configuration: {
-              ...(active.configuration ?? {}),
-              model: nextModel
-            }
+            configuration: mergedCfg as typeof active.configuration
           })
         }
-        addToast(`Model switched to ${nextModel}`, 'success')
+        addToast(
+          nextModel === 'Default' ? 'Using workspace default model' : `Model switched to ${nextModel}`,
+          'success'
+        )
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         setModelName(previousModel)
@@ -157,6 +179,7 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
     },
     [
       activeThread,
+      deleteCaseInsensitiveField,
       modelName,
       readWorkspaceConfig,
       setCaseInsensitiveField,

--- a/desktop/src/renderer/components/layout/ConversationPanel.tsx
+++ b/desktop/src/renderer/components/layout/ConversationPanel.tsx
@@ -24,7 +24,6 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
   const { activeThread, activeThreadId, loading } = useThreadStore()
   const turns = useConversationStore((s) => s.turns)
   const turnStatus = useConversationStore((s) => s.turnStatus)
-  const threadMode = useConversationStore((s) => s.threadMode)
   const connectionStatus = useConnectionStore((s) => s.status)
   const connectionErrorMessage = useConnectionStore((s) => s.errorMessage)
   const capabilities = useConnectionStore((s) => s.capabilities)
@@ -141,7 +140,6 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
           readRes.thread?.configuration && typeof readRes.thread.configuration === 'object'
             ? { ...(readRes.thread.configuration as Record<string, unknown>) }
             : {}
-        setCaseInsensitiveField(existingConfig, 'mode', threadMode)
         if (nextModel === 'Default') {
           deleteCaseInsensitiveField(existingConfig, 'model')
         } else {
@@ -183,7 +181,6 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
       modelName,
       readWorkspaceConfig,
       setCaseInsensitiveField,
-      threadMode,
       workspaceConfigPath
     ]
   )

--- a/desktop/src/renderer/components/layout/ConversationPanel.tsx
+++ b/desktop/src/renderer/components/layout/ConversationPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useThreadStore } from '../../stores/threadStore'
 import { useConversationStore } from '../../stores/conversationStore'
 import { useConnectionStore } from '../../stores/connectionStore'
+import { useModelCatalogStore } from '../../stores/modelCatalogStore'
 import { addToast } from '../../stores/toastStore'
 import { ThreadHeader } from '../conversation/ThreadHeader'
 import { MessageStream } from '../conversation/MessageStream'
@@ -27,9 +28,9 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
   const connectionStatus = useConnectionStore((s) => s.status)
   const connectionErrorMessage = useConnectionStore((s) => s.errorMessage)
   const capabilities = useConnectionStore((s) => s.capabilities)
-  const [modelOptions, setModelOptions] = useState<string[]>([])
+  const modelOptions = useModelCatalogStore((s) => s.modelOptions)
+  const modelCatalogStatus = useModelCatalogStore((s) => s.status)
   const [modelName, setModelName] = useState<string>('Default')
-  const [modelLoading, setModelLoading] = useState(false)
   const [modelApplying, setModelApplying] = useState(false)
 
   const showReconnectionBanner = connectionStatus === 'disconnected'
@@ -37,6 +38,7 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
     capabilities?.modelCatalogManagement === true &&
     connectionStatus === 'connected' &&
     Boolean(activeThreadId)
+  const modelLoading = modelApiAvailable && modelCatalogStatus === 'loading'
 
   const workspaceConfigPath = useMemo(() => {
     if (!workspacePath) return ''
@@ -84,54 +86,19 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
 
   useEffect(() => {
     let disposed = false
-    const loadModels = async (): Promise<void> => {
-      if (!modelApiAvailable || !activeThread) {
-        setModelOptions([])
-        try {
-          const workspaceCfg = await readWorkspaceConfig()
-          if (disposed) return
-          setModelName(resolveEffectiveModel(activeThread, workspaceCfg))
-        } catch {
-          const modelFromThread = activeThread?.configuration?.model ?? activeThread?.configuration?.Model
-          setModelName(typeof modelFromThread === 'string' && modelFromThread.trim() ? modelFromThread : 'Default')
-        }
-        return
-      }
-
-      setModelLoading(true)
+    const loadEffectiveModel = async (): Promise<void> => {
       try {
-        const [modelRes, workspaceCfg] = await Promise.all([
-          window.api.appServer.listModels(),
-          readWorkspaceConfig()
-        ])
+        const workspaceCfg = await readWorkspaceConfig()
         if (disposed) return
-        const typed = modelRes as {
-          success?: boolean
-          models?: Array<{ id?: string; Id?: string }>
-          errorMessage?: string
-        }
-        const options = typed.success && Array.isArray(typed.models)
-          ? typed.models.map((m) => String(m.id ?? m.Id ?? '').trim()).filter(Boolean)
-          : []
-        setModelOptions(Array.from(new Set(options)).sort((a, b) => a.localeCompare(b)))
         setModelName(resolveEffectiveModel(activeThread, workspaceCfg))
       } catch {
         if (disposed) return
-        setModelOptions([])
-        try {
-          const workspaceCfg = await readWorkspaceConfig()
-          if (disposed) return
-          setModelName(resolveEffectiveModel(activeThread, workspaceCfg))
-        } catch {
-          const modelFromThread = activeThread?.configuration?.model ?? activeThread?.configuration?.Model
-          setModelName(typeof modelFromThread === 'string' && modelFromThread.trim() ? modelFromThread : 'Default')
-        }
-      } finally {
-        if (!disposed) setModelLoading(false)
+        const modelFromThread = activeThread?.configuration?.model ?? activeThread?.configuration?.Model
+        setModelName(typeof modelFromThread === 'string' && modelFromThread.trim() ? modelFromThread : 'Default')
       }
     }
 
-    void loadModels()
+    void loadEffectiveModel()
     return () => {
       disposed = true
     }
@@ -139,7 +106,6 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
     activeThreadId,
     activeThread?.configuration?.Model,
     activeThread?.configuration?.model,
-    modelApiAvailable,
     readWorkspaceConfig,
     resolveEffectiveModel
   ])

--- a/desktop/src/renderer/components/layout/ConversationPanel.tsx
+++ b/desktop/src/renderer/components/layout/ConversationPanel.tsx
@@ -1,11 +1,14 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useThreadStore } from '../../stores/threadStore'
 import { useConversationStore } from '../../stores/conversationStore'
 import { useConnectionStore } from '../../stores/connectionStore'
+import { addToast } from '../../stores/toastStore'
 import { ThreadHeader } from '../conversation/ThreadHeader'
 import { MessageStream } from '../conversation/MessageStream'
 import { TurnStatusIndicator } from '../conversation/TurnStatusIndicator'
 import { InputComposer } from '../conversation/InputComposer'
 import { ConversationWelcome } from '../conversation/ConversationWelcome'
+import type { ThreadConfigurationWire } from '../../types/thread'
 
 interface ConversationPanelProps {
   workspacePath?: string
@@ -20,10 +23,181 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
   const { activeThread, activeThreadId, loading } = useThreadStore()
   const turns = useConversationStore((s) => s.turns)
   const turnStatus = useConversationStore((s) => s.turnStatus)
+  const threadMode = useConversationStore((s) => s.threadMode)
   const connectionStatus = useConnectionStore((s) => s.status)
   const connectionErrorMessage = useConnectionStore((s) => s.errorMessage)
+  const capabilities = useConnectionStore((s) => s.capabilities)
+  const [modelOptions, setModelOptions] = useState<string[]>([])
+  const [modelName, setModelName] = useState<string>('Default')
+  const [modelLoading, setModelLoading] = useState(false)
+  const [modelApplying, setModelApplying] = useState(false)
 
   const showReconnectionBanner = connectionStatus === 'disconnected'
+  const modelApiAvailable =
+    capabilities?.modelCatalogManagement === true &&
+    connectionStatus === 'connected' &&
+    Boolean(activeThreadId)
+
+  const workspaceConfigPath = useMemo(() => {
+    if (!workspacePath) return ''
+    const normalized = workspacePath.replace(/[\\/]+$/, '')
+    const sep = normalized.includes('\\') ? '\\' : '/'
+    return `${normalized}${sep}.craft${sep}config.json`
+  }, [workspacePath])
+
+  const readWorkspaceConfig = useCallback(async (): Promise<Record<string, unknown>> => {
+    if (!workspaceConfigPath) return {}
+    const raw = await window.api.file.readFile(workspaceConfigPath)
+    if (!raw.trim()) return {}
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  }, [workspaceConfigPath])
+
+  const setCaseInsensitiveField = useCallback(
+    (target: Record<string, unknown>, key: string, value: unknown): void => {
+      const lower = key.toLowerCase()
+      const existingKey = Object.keys(target).find((k) => k.toLowerCase() === lower)
+      if (existingKey) {
+        target[existingKey] = value
+      } else {
+        target[key] = value
+      }
+    },
+    []
+  )
+
+  const resolveEffectiveModel = useCallback(
+    (thread: typeof activeThread, workspaceCfg: Record<string, unknown>): string => {
+      const workspaceModelRaw = workspaceCfg.Model ?? workspaceCfg.model
+      const workspaceModel =
+        typeof workspaceModelRaw === 'string' && workspaceModelRaw.trim().length > 0
+          ? workspaceModelRaw
+          : null
+      const modelFromThread = thread?.configuration?.model ?? thread?.configuration?.Model
+      if (typeof modelFromThread === 'string' && modelFromThread.trim()) {
+        return modelFromThread
+      }
+      return workspaceModel ?? 'Default'
+    },
+    []
+  )
+
+  useEffect(() => {
+    let disposed = false
+    const loadModels = async (): Promise<void> => {
+      if (!modelApiAvailable || !activeThread) {
+        setModelOptions([])
+        try {
+          const workspaceCfg = await readWorkspaceConfig()
+          if (disposed) return
+          setModelName(resolveEffectiveModel(activeThread, workspaceCfg))
+        } catch {
+          const modelFromThread = activeThread?.configuration?.model ?? activeThread?.configuration?.Model
+          setModelName(typeof modelFromThread === 'string' && modelFromThread.trim() ? modelFromThread : 'Default')
+        }
+        return
+      }
+
+      setModelLoading(true)
+      try {
+        const [modelRes, workspaceCfg] = await Promise.all([
+          window.api.appServer.listModels(),
+          readWorkspaceConfig()
+        ])
+        if (disposed) return
+        const typed = modelRes as {
+          success?: boolean
+          models?: Array<{ id?: string; Id?: string }>
+          errorMessage?: string
+        }
+        const options = typed.success && Array.isArray(typed.models)
+          ? typed.models.map((m) => String(m.id ?? m.Id ?? '').trim()).filter(Boolean)
+          : []
+        setModelOptions(Array.from(new Set(options)).sort((a, b) => a.localeCompare(b)))
+        setModelName(resolveEffectiveModel(activeThread, workspaceCfg))
+      } catch {
+        if (disposed) return
+        setModelOptions([])
+        try {
+          const workspaceCfg = await readWorkspaceConfig()
+          if (disposed) return
+          setModelName(resolveEffectiveModel(activeThread, workspaceCfg))
+        } catch {
+          const modelFromThread = activeThread?.configuration?.model ?? activeThread?.configuration?.Model
+          setModelName(typeof modelFromThread === 'string' && modelFromThread.trim() ? modelFromThread : 'Default')
+        }
+      } finally {
+        if (!disposed) setModelLoading(false)
+      }
+    }
+
+    void loadModels()
+    return () => {
+      disposed = true
+    }
+  }, [
+    activeThreadId,
+    activeThread?.configuration?.Model,
+    activeThread?.configuration?.model,
+    modelApiAvailable,
+    readWorkspaceConfig,
+    resolveEffectiveModel
+  ])
+
+  const handleModelChange = useCallback(
+    async (nextModel: string): Promise<void> => {
+      if (!activeThread || !workspaceConfigPath || !nextModel || nextModel === modelName) return
+      setModelApplying(true)
+      const previousModel = modelName
+      setModelName(nextModel)
+      try {
+        const workspaceCfg = await readWorkspaceConfig()
+        setCaseInsensitiveField(workspaceCfg, 'Model', nextModel)
+        await window.api.file.writeFile(workspaceConfigPath, `${JSON.stringify(workspaceCfg, null, 2)}\n`)
+
+        const readRes = (await window.api.appServer.sendRequest('thread/read', {
+          threadId: activeThread.id,
+          includeTurns: false
+        })) as { thread?: { configuration?: ThreadConfigurationWire | null } }
+        const existingConfig =
+          readRes.thread?.configuration && typeof readRes.thread.configuration === 'object'
+            ? { ...(readRes.thread.configuration as Record<string, unknown>) }
+            : {}
+        setCaseInsensitiveField(existingConfig, 'mode', threadMode)
+        setCaseInsensitiveField(existingConfig, 'model', nextModel)
+
+        await window.api.appServer.sendRequest('thread/config/update', {
+          threadId: activeThread.id,
+          config: existingConfig
+        })
+        const active = useThreadStore.getState().activeThread
+        if (active && active.id === activeThread.id) {
+          useThreadStore.getState().setActiveThread({
+            ...active,
+            configuration: {
+              ...(active.configuration ?? {}),
+              model: nextModel
+            }
+          })
+        }
+        addToast(`Model switched to ${nextModel}`, 'success')
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        setModelName(previousModel)
+        addToast(`Failed to switch model: ${msg}`, 'error')
+      } finally {
+        setModelApplying(false)
+      }
+    },
+    [
+      activeThread,
+      modelName,
+      readWorkspaceConfig,
+      setCaseInsensitiveField,
+      threadMode,
+      workspaceConfigPath
+    ]
+  )
 
   // Loading state: thread selected but full data not yet fetched
   if (activeThreadId && !activeThread && loading) {
@@ -114,7 +288,17 @@ export function ConversationPanel({ workspacePath = '' }: ConversationPanelProps
       <TurnStatusIndicator threadId={activeThread.id} />
 
       {/* Input composer */}
-      <InputComposer threadId={activeThread.id} workspacePath={workspacePath} />
+      <InputComposer
+        threadId={activeThread.id}
+        workspacePath={workspacePath}
+        modelName={modelName}
+        modelOptions={modelOptions}
+        modelLoading={modelLoading}
+        modelDisabled={modelApplying || !modelApiAvailable}
+        onModelChange={(m) => {
+          void handleModelChange(m)
+        }}
+      />
     </div>
   )
 }

--- a/desktop/src/renderer/stores/connectionStore.ts
+++ b/desktop/src/renderer/stores/connectionStore.ts
@@ -18,6 +18,7 @@ export interface ServerCapabilities {
   configOverride?: boolean
   cronManagement?: boolean
   heartbeatManagement?: boolean
+  modelCatalogManagement?: boolean
   [key: string]: unknown
 }
 

--- a/desktop/src/renderer/stores/modelCatalogStore.ts
+++ b/desktop/src/renderer/stores/modelCatalogStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand'
+
+export type ModelCatalogStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+interface ModelCatalogState {
+  status: ModelCatalogStatus
+  modelOptions: string[]
+}
+
+interface ModelCatalogActions {
+  loadIfNeeded(force?: boolean): Promise<void>
+  reset(): void
+}
+
+type ModelCatalogStore = ModelCatalogState & ModelCatalogActions
+
+let inFlightLoad: Promise<void> | null = null
+
+const initialState: ModelCatalogState = {
+  status: 'idle',
+  modelOptions: []
+}
+
+function parseModelOptions(payload: unknown): string[] {
+  const typed = payload as {
+    success?: boolean
+    models?: Array<{ id?: string; Id?: string }>
+  }
+  if (!typed.success || !Array.isArray(typed.models)) return []
+  return Array.from(
+    new Set(
+      typed.models
+        .map((m) => String(m.id ?? m.Id ?? '').trim())
+        .filter(Boolean)
+    )
+  ).sort((a, b) => a.localeCompare(b))
+}
+
+export const useModelCatalogStore = create<ModelCatalogStore>((set, get) => ({
+  ...initialState,
+
+  async loadIfNeeded(force = false) {
+    const current = get()
+    if (!force && (current.status === 'ready' || current.status === 'loading')) {
+      if (inFlightLoad) await inFlightLoad
+      return
+    }
+    if (inFlightLoad) {
+      await inFlightLoad
+      return
+    }
+
+    set({ status: 'loading' })
+    inFlightLoad = (async () => {
+      try {
+        const result = await window.api.appServer.listModels()
+        const options = parseModelOptions(result)
+        set({ modelOptions: options, status: 'ready' })
+      } catch {
+        // Silent fallback by design.
+        set({ modelOptions: [], status: 'error' })
+      } finally {
+        inFlightLoad = null
+      }
+    })()
+
+    await inFlightLoad
+  },
+
+  reset() {
+    inFlightLoad = null
+    set({ ...initialState })
+  }
+}))

--- a/desktop/src/renderer/stores/uiStore.ts
+++ b/desktop/src/renderer/stores/uiStore.ts
@@ -48,6 +48,8 @@ export interface UIState {
     images?: ImageAttachment[]
     /** Agent/plan chosen on Welcome before thread exists; applied after thread/read. */
     mode?: ThreadMode
+    /** Model chosen on Welcome before thread exists; applied after thread/read. */
+    model?: string
     createdAt: number
   } | null
 }
@@ -73,12 +75,12 @@ interface UIStore extends UIState {
   consumeComposerPrefill(): string | null
   /** Queue first turn for a thread created from the welcome composer. */
   setPendingWelcomeTurn(
-    payload: { threadId: string; text: string; images?: ImageAttachment[]; mode?: ThreadMode } | null
+    payload: { threadId: string; text: string; images?: ImageAttachment[]; mode?: ThreadMode; model?: string } | null
   ): void
   /** If pending matches threadId, return payload and clear; otherwise return null. */
   consumePendingWelcomeTurnIfMatch(
     threadId: string
-  ): { text: string; images?: ImageAttachment[]; mode?: ThreadMode } | null
+  ): { text: string; images?: ImageAttachment[]; mode?: ThreadMode; model?: string } | null
   /** Clear pending welcome turn when it targets the given thread (e.g. thread/read failed). */
   cancelPendingWelcomeTurnForThread(threadId: string): void
 }
@@ -199,11 +201,12 @@ export const useUIStore = create<UIStore & InternalState>((set, get) => ({
         clearTimeout(timer)
       }
       set({ pendingWelcomeTurn: null, _pendingWelcomeTimer: null })
-      const { text, images, mode } = p
+      const { text, images, mode, model } = p
       return {
         text,
         ...(images !== undefined ? { images } : {}),
-        ...(mode !== undefined ? { mode } : {})
+        ...(mode !== undefined ? { mode } : {}),
+        ...(model !== undefined ? { model } : {})
       }
     }
     return null

--- a/desktop/src/renderer/types/thread.ts
+++ b/desktop/src/renderer/types/thread.ts
@@ -30,10 +30,18 @@ export interface Turn {
   tokenUsage?: { inputTokens: number; outputTokens: number }
 }
 
+export interface ThreadConfigurationWire {
+  mode?: string
+  model?: string
+  Model?: string
+  [key: string]: unknown
+}
+
 export interface Thread extends ThreadSummary {
   workspacePath: string
   userId: string
   metadata: Record<string, unknown>
+  configuration?: ThreadConfigurationWire | null
   turns: Turn[]
 }
 

--- a/desktop/src/shared/locales/catalog.ts
+++ b/desktop/src/shared/locales/catalog.ts
@@ -168,7 +168,7 @@ const MESSAGES_EN = {
 
   // Conversation / input (high-traffic)
   'composer.placeholder.approval': 'Waiting for approval decision...',
-  'composer.placeholder.ask': 'Ask DotCraft anything',
+  'composer.placeholder.ask': 'Ask DotCraft anything…',
   'composer.placeholder.connecting': 'Connecting…',
   'welcomeComposer.hint.select':
     'Select a thread from the sidebar, type below, or pick a quick start.',
@@ -645,7 +645,7 @@ const MESSAGES_ZH: Record<MessageId, string> = {
   'main.status.reconnecting': '连接已断开，正在重新连接…',
 
   'composer.placeholder.approval': '等待审批结果…',
-  'composer.placeholder.ask': '向 DotCraft 提问',
+  'composer.placeholder.ask': '向 DotCraft 提问…',
   'composer.placeholder.connecting': '正在连接…',
   'welcomeComposer.hint.select': '在侧栏选择会话、在下方输入，或选择快速开始。',
   'welcomeComposer.hint.connecting': '正在连接工作区…',

--- a/desktop/src/shared/locales/catalog.ts
+++ b/desktop/src/shared/locales/catalog.ts
@@ -269,6 +269,8 @@ const MESSAGES_EN = {
   'composer.mode.agent': 'Agent',
   'composer.mode.plan': 'Plan',
   'composer.defaultModel': 'Default',
+  'composer.modelListLoading': 'Loading model list...',
+  'composer.selectModelTitle': 'Select model',
 
   // Detail / git (Phase 2)
   'commit.title': 'Commit Changes',
@@ -737,6 +739,8 @@ const MESSAGES_ZH: Record<MessageId, string> = {
   'composer.mode.agent': 'Agent',
   'composer.mode.plan': 'Plan',
   'composer.defaultModel': '默认',
+  'composer.modelListLoading': '正在加载模型列表...',
+  'composer.selectModelTitle': '选择模型',
 
   'commit.title': '提交更改',
   'commit.filesHeader': '待提交文件（{{written}} / {{all}}{{reverted}}）：',

--- a/specs/appserver-protocol.md
+++ b/specs/appserver-protocol.md
@@ -39,6 +39,7 @@ Purpose: Define a language-neutral JSON-RPC wire protocol that exposes Session C
 - [18. Skills Management Methods](#18-skills-management-methods)
 - [19. Command Management Methods](#19-command-management-methods)
 - [20. Channel Status Methods](#20-channel-status-methods)
+- [21. Model Catalog Methods](#21-model-catalog-methods)
 
 ---
 
@@ -65,7 +66,7 @@ The current v1 contract is based on the refactored Session Core, not on the earl
 
 | Bucket | V1 Items |
 |-------|----------|
-| **Guaranteed in v1** | Rich approval decisions (`accept`, `acceptForSession`, `acceptAlways`, `decline`, `cancel`), thread-scoped event subscription, accurate per-turn origin/initiator metadata, strict `historyMode` rules, separate wire DTO serialization with camelCase enums and lossless delta typing. Cron management methods (`cron/list`, `cron/remove`, `cron/enable`) with the `cronManagement` server capability flag. Heartbeat trigger method (`heartbeat/trigger`) with the `heartbeatManagement` capability flag. Skills management methods (`skills/list`, `skills/read`, `skills/setEnabled`) with the `skillsManagement` capability flag. Command management methods (`command/list`, `command/execute`) with the `commandManagement` capability flag. Channel status method (`channel/status`) with the `channelStatus` capability flag. |
+| **Guaranteed in v1** | Rich approval decisions (`accept`, `acceptForSession`, `acceptAlways`, `decline`, `cancel`), thread-scoped event subscription, accurate per-turn origin/initiator metadata, strict `historyMode` rules, separate wire DTO serialization with camelCase enums and lossless delta typing. Cron management methods (`cron/list`, `cron/remove`, `cron/enable`) with the `cronManagement` server capability flag. Heartbeat trigger method (`heartbeat/trigger`) with the `heartbeatManagement` capability flag. Skills management methods (`skills/list`, `skills/read`, `skills/setEnabled`) with the `skillsManagement` capability flag. Command management methods (`command/list`, `command/execute`) with the `commandManagement` capability flag. Channel status method (`channel/status`) with the `channelStatus` capability flag. Model catalog method (`model/list`) with the `modelCatalogManagement` capability flag. |
 | **Guaranteed with narrowed semantics** | `thread/list` is deterministic but **not cursor-paginated** in v1; archived threads are excluded by default and included only via an explicit filter. |
 | **Deferred from v1** | Structured extension capability registry beyond a flat namespace advertisement. Clients must treat extension namespaces as optional and discoverable, not required for core Session behavior. |
 
@@ -203,7 +204,8 @@ Client                              Server
     "cronManagement": true,
     "heartbeatManagement": true,
     "skillsManagement": true,
-    "commandManagement": true
+    "commandManagement": true,
+    "modelCatalogManagement": true
   }
 }
 ```
@@ -223,6 +225,7 @@ Client                              Server
 | `capabilities.heartbeatManagement` | boolean | Server supports heartbeat management methods (`heartbeat/trigger`). Absent or `false` when the heartbeat service is not configured. |
 | `capabilities.skillsManagement` | boolean | Server supports skills management methods (`skills/list`, `skills/read`, `skills/setEnabled`). Always `true` when the server has a `SkillsLoader` configured. |
 | `capabilities.commandManagement` | boolean | Server supports command management methods (`command/list`, `command/execute`). Always `true` when CommandRegistry is available. |
+| `capabilities.modelCatalogManagement` | boolean | Server supports model catalog methods (`model/list`). Present and `true` when workspace config is available for resolving merged `ApiKey` and `EndPoint`. |
 
 ### 3.3 `initialized`
 
@@ -2708,3 +2711,67 @@ Returns runtime status for all configured social and external channels.
 ### 20.4 Capability Advertisement
 
 Clients must check `capabilities.channelStatus` before calling `channel/status`. The capability is present and `true` when the AppServer has a `IChannelStatusProvider` configured, which requires an active `ChannelRunner` instance or a workspace config with at least one social/external channel section.
+
+---
+
+## 21. Model Catalog Methods
+
+### 21.1 Scope
+
+These methods expose provider model discovery based on the server's merged workspace configuration (`ApiKey`, `EndPoint`) so wire clients can populate model selectors without hardcoding model ids.
+
+Clients must check `capabilities.modelCatalogManagement` in the `initialize` response before calling `model/list`. If absent or `false`, the server returns `-32601` (Method not found).
+
+### 21.2 `ModelCatalogItem` Wire DTO
+
+```json
+{
+  "id": "gpt-4o-mini",
+  "ownedBy": "openai",
+  "createdAt": "2025-06-12T00:00:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Model id used in `config.Model` / request payloads. |
+| `ownedBy` | string | Provider-reported owner string when available; may be empty. |
+| `createdAt` | string (ISO 8601 UTC) | Provider-reported creation time. |
+
+### 21.3 `model/list`
+
+Returns available models from the configured OpenAI-compatible endpoint.
+
+**Direction**: client → server (request)
+
+**Params**: `{}` (empty object) or omitted.
+
+**Result**:
+
+```json
+{
+  "success": true,
+  "models": [
+    {
+      "id": "gpt-4o-mini",
+      "ownedBy": "openai",
+      "createdAt": "2025-06-12T00:00:00Z"
+    }
+  ]
+}
+```
+
+On provider/config errors, the method still returns a successful JSON-RPC response with structured error fields:
+
+```json
+{
+  "success": false,
+  "models": [],
+  "errorCode": "MissingApiKey",
+  "errorMessage": "API key is not configured."
+}
+```
+
+### 21.4 Capability Advertisement
+
+`capabilities.modelCatalogManagement` is present and `true` when the AppServer has a workspace config path available and can resolve merged config values for model discovery.

--- a/specs/desktop-client.md
+++ b/specs/desktop-client.md
@@ -222,7 +222,7 @@ Application state lives in the Renderer Process. It is the single source of trut
 | **Tokens** | `inputTokens`, `outputTokens` (cumulative for current turn) | `item/usage/delta` (additive), reset on `turn/started` |
 | **Approval** | `pendingApproval` (approval request params) or null | `item/approval/request` server request |
 | **FileChanges** | `changedFiles` (Map of filePath → FileDiff), where each `FileDiff` contains: `filePath`, `turnId`, `additions`, `deletions`, `diffHunks`, `status` ('written' or 'reverted'), `isNewFile` | Extracted from completed `toolCall`/`toolResult` items where tool is `FileWrite` / `FileEdit`. Keyed by file path so that multiple edits to the same file across turns produce a single aggregated entry in the Detail Panel, while per-turn entries remain in the Turn Completion Summary. |
-| **UI** | `sidebarCollapsed`, `detailPanelTab`, `detailPanelVisible`, `inputValue`, `agentMode`, `activeMainView` ('conversation' \| 'skills' \| 'automations'), `automationsTab` ('tasks' \| 'cron') | User interactions |
+| **UI** | `sidebarCollapsed`, `detailPanelTab`, `detailPanelVisible`, `inputValue`, `agentMode`, `activeMainView` ('conversation' \| 'skills' \| 'automations'), `automationsTab` ('tasks' \| 'cron'), `pendingWelcomeTurn` ({ `threadId`, `text`, `images?`, `mode?`, `model?`, `createdAt` }) | User interactions and welcome handoff flow |
 | **CronJobs** | `cronJobs` (CronJobInfo[]), `selectedCronJobId`, `cronLoading`, `cronError` | `cron/list` response, `cron/stateChanged` notifications |
 | **ComposerAttachments** | Local to `InputComposer` component state (not global store). `images: ImageAttachment[]` for image attachments shown in the image strip. `ImageAttachment`: `{ tempPath: string, dataUrl: string, fileName: string, mimeType: string }`. File references are **not** stored as separate state — they exist as inline `<span>` elements inside the `contentEditable` div and are extracted at send time by walking the DOM. | User attachment interactions (drag-drop, paste for images; `@` selection for inline file tags). Image state cleared on send; inline tags are cleared with the div content. |
 
@@ -1175,10 +1175,15 @@ The input area is a **`contentEditable` div** rather than a plain `<textarea>`. 
 
 ### 12.3 Model Selector
 
-A dropdown button in the bottom-left of the composer:
+A dropdown control in the bottom-left of the composer:
 
 - Shows the currently selected model name (e.g., "GPT-5.3-Codex" or the configured model from workspace settings).
-- In V1, this is read-only/informational — it reflects the model configured in `.craft/config.json`. Future versions may allow per-thread model selection.
+- Uses `model/list` when the server advertises `capabilities.modelCatalogManagement === true`; options are sorted and deduplicated.
+- Supports both thread composer (`InputComposer`) and welcome composer (`ConversationWelcome`) surfaces.
+- On user selection, Desktop persists the workspace `Model` field in `.craft/config.json` immediately (without overwriting unrelated keys).
+- For an active thread, Desktop applies the selection via `thread/config/update` so subsequent turns use the new model.
+- For Welcome (no thread yet), Desktop carries the selected model in `pendingWelcomeTurn` and applies it to the newly created thread via `thread/config/update` before the first `turn/start`.
+- If `model/list` is unsupported or fails, fallback is silent (no warning toast loops). The UI continues to display the effective configured model from workspace config; `Default` is shown only when config has no model.
 
 ### 12.4 Send Button
 
@@ -1253,6 +1258,12 @@ The existing `InputComposer` sends clipboard images as `{ type: "localImage", da
 #### 12.6.6 ConversationWelcome Parity
 
 The welcome screen composer (`ConversationWelcome`) must support the same image attachment methods (paste, drag-and-drop) as `InputComposer`. The collected `ImageAttachment[]` is passed into the `pendingWelcomeTurn` store entry alongside the text, so `App.tsx` can include the image parts when it fires `turn/start` after the thread is created.
+
+The welcome flow also carries `mode` and `model` in `pendingWelcomeTurn`:
+
+- `mode` is applied (`thread/mode/set` or merged config update).
+- `model` is applied through `thread/config/update` before first `turn/start`.
+- This guarantees the first turn from Welcome uses the selected model.
 
 ---
 

--- a/specs/desktop-client.md
+++ b/specs/desktop-client.md
@@ -1188,6 +1188,7 @@ A dropdown control in the bottom-left of the composer:
 - For Welcome (no thread yet), Desktop carries the selected model in `pendingWelcomeTurn` and applies it to the newly created thread via `thread/config/update` before the first `turn/start`.
 - While the shared catalog is loading, the UI shows a localized loading label in the same plain-text slot used when the catalog is unavailable (not a dropdown).
 - If `model/list` is unsupported or fails, fallback is silent (no warning toast loops). The UI continues to display the effective configured model from workspace config; `Default` is shown only when config has no model.
+- The catalog label `Default` is UI-only (meaning “no model override”); it is never written to `.craft/config.json` or sent as a thread `model` value—clearing the override removes the `Model` / `model` field instead.
 
 ### 12.4 Send Button
 

--- a/specs/desktop-client.md
+++ b/specs/desktop-client.md
@@ -1165,7 +1165,7 @@ Images are attached via **clipboard paste** or **drag-and-drop** onto the compos
 The input area is a **`contentEditable` div** rather than a plain `<textarea>`. This is required to support inline file reference tags (non-editable pill elements) embedded within the user's free-form text. Visually and functionally it behaves like a multi-line text input with the following additions:
 
 - **Multi-line**: Grows vertically as the user types (1 line minimum, 8 lines maximum before scrolling internally).
-- **Placeholder**: "Ask DotCraft anything" shown as a dimmed pseudo-element when the div is empty.
+- **Placeholder**: "Ask DotCraft anything…" shown as a dimmed pseudo-element when the div is empty.
 - **Submit**: `Enter` sends the message (calls `turn/start`). `Shift+Enter` inserts a newline.
 - **Disabled state**: When a turn is running (`turnStatus = running`), the input area shows a subtle disabled overlay. The user can still type; pressing `Enter` queues the message as a pending follow-up (sent automatically when the current turn completes).
 - **Image paste**: Pasting an image from the clipboard (Ctrl+V) attaches it to the image strip. See §12.6.

--- a/specs/desktop-client.md
+++ b/specs/desktop-client.md
@@ -1186,13 +1186,13 @@ A dropdown control in the bottom-left of the composer:
 - On user selection, Desktop persists the workspace `Model` field in `.craft/config.json` immediately (without overwriting unrelated keys).
 - For an active thread, Desktop applies the selection via `thread/config/update` so subsequent turns use the new model.
 - For Welcome (no thread yet), Desktop carries the selected model in `pendingWelcomeTurn` and applies it to the newly created thread via `thread/config/update` before the first `turn/start`.
-- While the shared catalog is loading, the selector is disabled and displays a localized loading label.
+- While the shared catalog is loading, the UI shows a localized loading label in the same plain-text slot used when the catalog is unavailable (not a dropdown).
 - If `model/list` is unsupported or fails, fallback is silent (no warning toast loops). The UI continues to display the effective configured model from workspace config; `Default` is shown only when config has no model.
 
 ### 12.4 Send Button
 
 - **Active state**: Accent-colored arrow icon. Clickable when input is non-empty and turn is idle.
-- **Disabled state**: Dimmed when input is empty.
+- **Disabled state**: Dimmed when input is empty. While the shared model catalog is loading (when model catalog management is enabled), Send is disabled and Enter does not submit, on both Welcome and in-thread composers.
 - **Loading state**: Shows a spinner when a turn is being submitted.
 - **Cancel state**: When a turn is running, the send button transforms into a "Stop" button (square icon) that sends `turn/interrupt`.
 

--- a/specs/desktop-client.md
+++ b/specs/desktop-client.md
@@ -223,6 +223,7 @@ Application state lives in the Renderer Process. It is the single source of trut
 | **Approval** | `pendingApproval` (approval request params) or null | `item/approval/request` server request |
 | **FileChanges** | `changedFiles` (Map of filePath → FileDiff), where each `FileDiff` contains: `filePath`, `turnId`, `additions`, `deletions`, `diffHunks`, `status` ('written' or 'reverted'), `isNewFile` | Extracted from completed `toolCall`/`toolResult` items where tool is `FileWrite` / `FileEdit`. Keyed by file path so that multiple edits to the same file across turns produce a single aggregated entry in the Detail Panel, while per-turn entries remain in the Turn Completion Summary. |
 | **UI** | `sidebarCollapsed`, `detailPanelTab`, `detailPanelVisible`, `inputValue`, `agentMode`, `activeMainView` ('conversation' \| 'skills' \| 'automations'), `automationsTab` ('tasks' \| 'cron'), `pendingWelcomeTurn` ({ `threadId`, `text`, `images?`, `mode?`, `model?`, `createdAt` }) | User interactions and welcome handoff flow |
+| **ModelCatalog** | `status` (`idle` / `loading` / `ready` / `error`), `modelOptions: string[]` | Loaded once after connection is ready when `capabilities.modelCatalogManagement === true`; consumed by both `ConversationWelcome` and `InputComposer` |
 | **CronJobs** | `cronJobs` (CronJobInfo[]), `selectedCronJobId`, `cronLoading`, `cronError` | `cron/list` response, `cron/stateChanged` notifications |
 | **ComposerAttachments** | Local to `InputComposer` component state (not global store). `images: ImageAttachment[]` for image attachments shown in the image strip. `ImageAttachment`: `{ tempPath: string, dataUrl: string, fileName: string, mimeType: string }`. File references are **not** stored as separate state — they exist as inline `<span>` elements inside the `contentEditable` div and are extracted at send time by walking the DOM. | User attachment interactions (drag-drop, paste for images; `@` selection for inline file tags). Image state cleared on send; inline tags are cleared with the div content. |
 
@@ -1178,11 +1179,14 @@ The input area is a **`contentEditable` div** rather than a plain `<textarea>`. 
 A dropdown control in the bottom-left of the composer:
 
 - Shows the currently selected model name (e.g., "GPT-5.3-Codex" or the configured model from workspace settings).
-- Uses `model/list` when the server advertises `capabilities.modelCatalogManagement === true`; options are sorted and deduplicated.
+- Uses a shared renderer-side model catalog cache loaded after connection is ready when `capabilities.modelCatalogManagement === true`.
+- The catalog is fetched once per connected session (and reset on disconnect/error), then reused by both Welcome and thread composer surfaces.
+- `model/list` payload parsing tolerates both `id` and `Id`; options are sorted and deduplicated.
 - Supports both thread composer (`InputComposer`) and welcome composer (`ConversationWelcome`) surfaces.
 - On user selection, Desktop persists the workspace `Model` field in `.craft/config.json` immediately (without overwriting unrelated keys).
 - For an active thread, Desktop applies the selection via `thread/config/update` so subsequent turns use the new model.
 - For Welcome (no thread yet), Desktop carries the selected model in `pendingWelcomeTurn` and applies it to the newly created thread via `thread/config/update` before the first `turn/start`.
+- While the shared catalog is loading, the selector is disabled and displays a localized loading label.
 - If `model/list` is unsupported or fails, fallback is silent (no warning toast loops). The UI continues to display the effective configured model from workspace config; `Default` is shown only when config has no model.
 
 ### 12.4 Send Button

--- a/src/DotCraft.Core/Agents/AgentFactory.cs
+++ b/src/DotCraft.Core/Agents/AgentFactory.cs
@@ -379,7 +379,7 @@ public sealed class AgentFactory : IAsyncDisposable
 
         // Reverse middleware control:
         // OpenAIChatClient => ImageContentSanitizingChatClient => [DynamicToolInjectionChatClient] => FunctionInvokingChatClient => TracingChatClient
-        var chatClientBuilder = new ChatClientBuilder(_chatClient.AsIChatClient());
+        var chatClientBuilder = new ChatClientBuilder(ctx.ChatClient.AsIChatClient());
         if (_traceCollector != null)
         {
             var tc = _traceCollector;

--- a/src/DotCraft.Core/Agents/AgentFactory.cs
+++ b/src/DotCraft.Core/Agents/AgentFactory.cs
@@ -25,10 +25,6 @@ namespace DotCraft.Agents;
 public sealed class AgentFactory : IAsyncDisposable
 {
     private readonly AppConfig _config;
-    private readonly MemoryStore _memoryStore;
-    private readonly SkillsLoader _skillsLoader;
-    private readonly string _dotcraftPath;
-    private readonly string _workspacePath;
     private readonly ChatClient _chatClient;
     private readonly ConcurrentDictionary<string, TokenTracker> _tokenTrackers = new();
     private readonly ConcurrentDictionary<string, int> _lastConsolidated = new();
@@ -63,10 +59,6 @@ public sealed class AgentFactory : IAsyncDisposable
         HookRunner? hookRunner = null)
     {
         _config = config;
-        _memoryStore = memoryStore;
-        _skillsLoader = skillsLoader;
-        _dotcraftPath = dotcraftPath;
-        _workspacePath = workspacePath;
         _traceCollector = traceCollector;
         _customCommandLoader = customCommandLoader;
         _planStore = planStore;
@@ -74,14 +66,14 @@ public sealed class AgentFactory : IAsyncDisposable
         _hookRunner = hookRunner;
         _globalEnabledToolNames = ResolveGlobalEnabledToolNames(_config);
 
-        var openAIClient = new OpenAIClient(new ApiKeyCredential(config.ApiKey), new OpenAIClientOptions
+        var client = new OpenAIClient(new ApiKeyCredential(config.ApiKey), new OpenAIClientOptions
         {
             Endpoint = new Uri(config.EndPoint)
         });
-        _chatClient = openAIClient.GetChatClient(_config.Model);
+        _chatClient = client.GetChatClient(_config.Model);
 
         string consolidationModel = string.IsNullOrWhiteSpace(_config.ConsolidationModel) ? _config.Model : _config.ConsolidationModel;
-        var consolidationChatClient = openAIClient.GetChatClient(consolidationModel);
+        var consolidationChatClient = client.GetChatClient(consolidationModel);
 
         Consolidator = new MemoryConsolidator(consolidationChatClient, memoryStore, onConsolidatorStatus);
 

--- a/src/DotCraft.Core/Configuration/OpenAIModelCatalog.cs
+++ b/src/DotCraft.Core/Configuration/OpenAIModelCatalog.cs
@@ -1,0 +1,149 @@
+using System.ClientModel;
+using OpenAI;
+
+namespace DotCraft.Configuration;
+
+public enum OpenAIModelCatalogErrorCode
+{
+    None = 0,
+    MissingApiKey,
+    InvalidEndpoint,
+    Unauthorized,
+    Forbidden,
+    EndpointNotSupported,
+    Network,
+    Timeout,
+    Unknown
+}
+
+public sealed class OpenAIModelCatalogEntry
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string OwnedBy { get; set; } = string.Empty;
+
+    public DateTimeOffset CreatedAt { get; set; }
+}
+
+public sealed class OpenAIModelCatalogResult
+{
+    public bool Success { get; set; }
+
+    public List<OpenAIModelCatalogEntry> Models { get; set; } = [];
+
+    public OpenAIModelCatalogErrorCode ErrorCode { get; set; } = OpenAIModelCatalogErrorCode.None;
+
+    public string? ErrorMessage { get; set; }
+}
+
+public static class OpenAIModelCatalog
+{
+    public static async Task<OpenAIModelCatalogResult> FetchAsync(
+        AppConfig config,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            return Failure(
+                OpenAIModelCatalogErrorCode.MissingApiKey,
+                "API key is not configured.");
+        }
+
+        if (!Uri.TryCreate(config.EndPoint, UriKind.Absolute, out var endpoint))
+        {
+            return Failure(
+                OpenAIModelCatalogErrorCode.InvalidEndpoint,
+                "Endpoint is invalid.");
+        }
+
+        try
+        {
+            var client = new OpenAIClient(
+                new ApiKeyCredential(config.ApiKey),
+                new OpenAIClientOptions { Endpoint = endpoint });
+
+            var modelClient = client.GetOpenAIModelClient();
+            var models = await modelClient.GetModelsAsync(cancellationToken);
+
+            var entries = models.Value
+                .Select(m => new OpenAIModelCatalogEntry
+                {
+                    Id = m.Id,
+                    OwnedBy = m.OwnedBy ?? string.Empty,
+                    CreatedAt = m.CreatedAt
+                })
+                .OrderBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            return new OpenAIModelCatalogResult
+            {
+                Success = true,
+                Models = entries
+            };
+        }
+        catch (ClientResultException ex)
+        {
+            var status = ResolveStatusCode(ex);
+            if (status == 401)
+                return Failure(OpenAIModelCatalogErrorCode.Unauthorized, "Request was unauthorized.");
+            if (status == 403)
+                return Failure(OpenAIModelCatalogErrorCode.Forbidden, "Request was forbidden.");
+            if (status == 404 || status == 405)
+            {
+                return Failure(
+                    OpenAIModelCatalogErrorCode.EndpointNotSupported,
+                    "Endpoint does not support model listing.");
+            }
+
+            return Failure(
+                OpenAIModelCatalogErrorCode.Unknown,
+                string.IsNullOrWhiteSpace(ex.Message) ? "OpenAI request failed." : ex.Message);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return Failure(OpenAIModelCatalogErrorCode.Timeout, "Request timed out.");
+        }
+        catch (HttpRequestException ex)
+        {
+            return Failure(
+                OpenAIModelCatalogErrorCode.Network,
+                string.IsNullOrWhiteSpace(ex.Message) ? "Network request failed." : ex.Message);
+        }
+        catch (TaskCanceledException)
+        {
+            return Failure(OpenAIModelCatalogErrorCode.Timeout, "Request timed out.");
+        }
+        catch (Exception ex)
+        {
+            return Failure(
+                OpenAIModelCatalogErrorCode.Unknown,
+                string.IsNullOrWhiteSpace(ex.Message) ? "Unknown error." : ex.Message);
+        }
+    }
+
+    private static OpenAIModelCatalogResult Failure(OpenAIModelCatalogErrorCode code, string message)
+        => new()
+        {
+            Success = false,
+            ErrorCode = code,
+            ErrorMessage = message,
+            Models = []
+        };
+
+    private static int ResolveStatusCode(ClientResultException ex)
+    {
+        var type = ex.GetType();
+        var statusProp = type.GetProperty("Status")
+            ?? type.GetProperty("StatusCode");
+
+        if (statusProp?.GetValue(ex) is int statusCode)
+            return statusCode;
+
+        if (statusProp?.GetValue(ex) is short statusCodeShort)
+            return statusCodeShort;
+
+        return 0;
+    }
+}

--- a/src/DotCraft.Core/DashBoard/DashBoardMiddleware.cs
+++ b/src/DotCraft.Core/DashBoard/DashBoardMiddleware.cs
@@ -241,6 +241,30 @@ public static class DashBoardMiddleware
             await SaveConfigAsync(ctx, workspaceConfigPath, sensitivePaths, logger);
         });
 
+        endpoints.MapGet("/dashboard/api/config/models", async (HttpContext ctx) =>
+        {
+            var workspaceConfigPath = Path.Combine(paths.CraftPath, "config.json");
+            var config = AppConfig.LoadWithGlobalFallback(workspaceConfigPath);
+            var result = await OpenAIModelCatalog.FetchAsync(config, ctx.RequestAborted);
+
+            if (!result.Success)
+            {
+                return Results.Json(new
+                {
+                    success = false,
+                    errorCode = result.ErrorCode.ToString(),
+                    errorMessage = result.ErrorMessage,
+                    models = Array.Empty<OpenAIModelCatalogEntry>()
+                }, RawJsonOptions, statusCode: MapModelCatalogStatusCode(result.ErrorCode));
+            }
+
+            return Results.Json(new
+            {
+                success = true,
+                models = result.Models
+            }, RawJsonOptions);
+        });
+
         if (tokenUsageStore != null)
         {
             endpoints.MapGet("/dashboard/api/token-usage", () =>
@@ -468,4 +492,16 @@ public static class DashBoardMiddleware
             });
         }
     }
+
+    private static int MapModelCatalogStatusCode(OpenAIModelCatalogErrorCode code) => code switch
+    {
+        OpenAIModelCatalogErrorCode.MissingApiKey => StatusCodes.Status400BadRequest,
+        OpenAIModelCatalogErrorCode.InvalidEndpoint => StatusCodes.Status400BadRequest,
+        OpenAIModelCatalogErrorCode.Unauthorized => StatusCodes.Status401Unauthorized,
+        OpenAIModelCatalogErrorCode.Forbidden => StatusCodes.Status403Forbidden,
+        OpenAIModelCatalogErrorCode.EndpointNotSupported => StatusCodes.Status404NotFound,
+        OpenAIModelCatalogErrorCode.Timeout => StatusCodes.Status504GatewayTimeout,
+        OpenAIModelCatalogErrorCode.Network => StatusCodes.Status502BadGateway,
+        _ => StatusCodes.Status500InternalServerError
+    };
 }

--- a/src/DotCraft.Core/Protocol/AppServer/AppServerProtocol.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/AppServerProtocol.cs
@@ -199,6 +199,12 @@ public sealed class AppServerServerCapabilities
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool ChannelStatus { get; set; }
+
+    /// <summary>
+    /// Server supports model catalog methods (<c>model/list</c>).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool ModelCatalogManagement { get; set; }
 }
 
 // ───── thread/start ─────
@@ -833,6 +839,43 @@ public sealed class ChannelListResult
     public List<ChannelInfo> Channels { get; set; } = [];
 }
 
+// ───── model/list (model catalog management) ─────
+
+/// <summary>
+/// Params for <see cref="AppServerMethods.ModelList"/>.
+/// </summary>
+public sealed class ModelListParams
+{
+}
+
+/// <summary>
+/// One provider model entry.
+/// </summary>
+public sealed class ModelCatalogItem
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string OwnedBy { get; set; } = string.Empty;
+
+    public DateTimeOffset CreatedAt { get; set; }
+}
+
+/// <summary>
+/// Result for <see cref="AppServerMethods.ModelList"/>.
+/// </summary>
+public sealed class ModelListResult
+{
+    public bool Success { get; set; }
+
+    public List<ModelCatalogItem> Models { get; set; } = [];
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ErrorCode { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ErrorMessage { get; set; }
+}
+
 // ───── Wire protocol method name constants ─────
 
 public static class AppServerMethods
@@ -850,6 +893,7 @@ public static class AppServerMethods
     /// See spec Section 20.
     /// </summary>
     public const string ChannelStatus = "channel/status";
+    public const string ModelList = "model/list";
     public const string ThreadStart = "thread/start";
     public const string ThreadResume = "thread/resume";
     public const string ThreadList = "thread/list";

--- a/src/DotCraft.Core/Protocol/AppServer/AppServerRequestHandler.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/AppServerRequestHandler.cs
@@ -96,6 +96,7 @@ public sealed class AppServerRequestHandler(
                 AppServerMethods.Initialize => HandleInitializeAsync(msg, ct),
                 AppServerMethods.ChannelList => HandleChannelListAsync(msg, ct),
                 AppServerMethods.ChannelStatus => HandleChannelStatusAsync(msg, ct),
+                AppServerMethods.ModelList => HandleModelListAsync(msg, ct),
                 AppServerMethods.ThreadStart => HandleThreadStartAsync(msg, ct),
                 AppServerMethods.ThreadResume => HandleThreadResumeAsync(msg, ct),
                 AppServerMethods.ThreadList => HandleThreadListAsync(msg, ct),
@@ -178,7 +179,8 @@ public sealed class AppServerRequestHandler(
                 SkillsManagement = skillsLoader != null,
                 CommandManagement = true,
                 Automations = automationsHandler != null,
-                ChannelStatus = _channelStatusProvider != null
+                ChannelStatus = _channelStatusProvider != null,
+                ModelCatalogManagement = !string.IsNullOrWhiteSpace(workspaceCraftPath)
             },
             DashboardUrl = _dashboardUrl
         };
@@ -354,6 +356,31 @@ public sealed class AppServerRequestHandler(
 
         var statuses = _channelStatusProvider.GetChannelStatuses();
         return Task.FromResult<object?>(new ChannelStatusResult { Channels = [.. statuses] });
+    }
+
+    private async Task<object?> HandleModelListAsync(AppServerIncomingMessage msg, CancellationToken ct)
+    {
+        _ = GetParams<ModelListParams>(msg);
+
+        if (string.IsNullOrWhiteSpace(workspaceCraftPath))
+            throw AppServerErrors.MethodNotFound(AppServerMethods.ModelList);
+
+        var configPath = Path.Combine(workspaceCraftPath, "config.json");
+        var config = AppConfig.LoadWithGlobalFallback(configPath);
+        var result = await OpenAIModelCatalog.FetchAsync(config, ct);
+
+        return new ModelListResult
+        {
+            Success = result.Success,
+            Models = [.. result.Models.Select(m => new ModelCatalogItem
+            {
+                Id = m.Id,
+                OwnedBy = m.OwnedBy,
+                CreatedAt = m.CreatedAt
+            })],
+            ErrorCode = result.Success ? null : result.ErrorCode.ToString(),
+            ErrorMessage = result.Success ? null : result.ErrorMessage
+        };
     }
 
     private async Task<object?> HandleThreadReadAsync(AppServerIncomingMessage msg, CancellationToken ct)

--- a/src/DotCraft.Core/Protocol/AppServer/AppServerWireClient.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/AppServerWireClient.cs
@@ -201,6 +201,33 @@ public sealed class AppServerWireClient(Stream input, Stream output) : IAsyncDis
     }
 
     // -------------------------------------------------------------------------
+    // Model catalog management (model/list)
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Lists provider models from the server's configured OpenAI-compatible endpoint.
+    /// Requires the server to advertise <c>modelCatalogManagement</c> capability.
+    /// </summary>
+    public async Task<ModelListResult> ModelListAsync(CancellationToken ct = default)
+    {
+        var doc = await SendRequestAsync(
+            AppServerMethods.ModelList,
+            new ModelListParams(),
+            ct: ct);
+
+        ThrowIfError(doc, "model/list");
+
+        var result = doc.RootElement.GetProperty("result");
+        return JsonSerializer.Deserialize<ModelListResult>(result.GetRawText(), SessionWireJsonOptions.Default)
+               ?? new ModelListResult
+               {
+                   Success = false,
+                   ErrorCode = "Unknown",
+                   ErrorMessage = "Server returned an empty model list payload."
+               };
+    }
+
+    // -------------------------------------------------------------------------
     // Cron management (spec Section 16)
     // -------------------------------------------------------------------------
 

--- a/src/DotCraft.Core/Protocol/SessionService.cs
+++ b/src/DotCraft.Core/Protocol/SessionService.cs
@@ -13,6 +13,8 @@ using DotCraft.Tracing;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using OpenAI;
+using System.ClientModel;
 
 namespace DotCraft.Protocol;
 
@@ -995,6 +997,9 @@ public sealed class SessionService(
             ? AgentMode.Plan
             : AgentMode.Agent;
         var mm = GetOrCreateModeManager(threadId, mode);
+        var baseCtx = agentFactory.ToolProviderContext;
+        var threadChatClient = ResolveThreadChatClient(baseCtx, config);
+        var threadBaseContext = CloneContextWithChatClient(baseCtx, threadChatClient);
 
         ToolProviderContext? scopedContext = null;
         if (!string.IsNullOrEmpty(config.WorkspaceOverride))
@@ -1004,12 +1009,11 @@ public sealed class SessionService(
 
             var scopedMemory = new MemoryStore(craftPath);
             var scopedSkills = new SkillsLoader(craftPath);
-            var baseCtx = agentFactory.ToolProviderContext;
 
             scopedContext = new ToolProviderContext
             {
                 Config = baseCtx.Config,
-                ChatClient = baseCtx.ChatClient,
+                ChatClient = threadChatClient,
                 WorkspacePath = config.WorkspaceOverride,
                 BotPath = craftPath,
                 MemoryStore = scopedMemory,
@@ -1036,7 +1040,7 @@ public sealed class SessionService(
                 throw new InvalidOperationException($"Tool profile '{config.ToolProfile}' is not registered.");
             }
 
-            var toolCtx = scopedContext ?? agentFactory.ToolProviderContext;
+            var toolCtx = scopedContext ?? threadBaseContext;
             profileTools = agentFactory.CreateToolsFromProviders(profileProviders, toolCtx);
         }
 
@@ -1044,7 +1048,7 @@ public sealed class SessionService(
         {
             if (profileTools is not { Count: > 0 })
                 throw new InvalidOperationException("UseToolProfileOnly requires a registered ToolProfile with at least one tool.");
-            var toolCtx2 = scopedContext ?? agentFactory.ToolProviderContext;
+            var toolCtx2 = scopedContext ?? threadBaseContext;
             return agentFactory.CreateAgentWithTools(profileTools, mm, toolCtx2, config.AgentInstructions);
         }
 
@@ -1060,12 +1064,13 @@ public sealed class SessionService(
 
             if (profileTools != null)
             {
-                var tools = agentFactory.CreateToolsForMode(mode);
+                var tools = agentFactory.CreateToolsForMode(mode, threadBaseContext);
                 tools.AddRange(profileTools);
-                return agentFactory.CreateAgentWithTools(tools, mm, agentFactory.ToolProviderContext);
+                return agentFactory.CreateAgentWithTools(tools, mm, threadBaseContext);
             }
 
-            return agentFactory.CreateAgentForMode(mode, mm);
+            var modeTools = agentFactory.CreateToolsForMode(mode, threadBaseContext);
+            return agentFactory.CreateAgentWithTools(modeTools, mm, threadBaseContext);
         }
 
         // Dispose previous per-thread MCP manager if replacing config
@@ -1105,10 +1110,54 @@ public sealed class SessionService(
             return agentFactory.CreateAgentWithTools(modeTools, mm, effectiveContext);
         }
 
-        var toolsWithMcp = agentFactory.CreateToolsForMode(mode);
+        var toolsWithMcp = agentFactory.CreateToolsForMode(mode, threadBaseContext);
         if (profileTools != null)
             toolsWithMcp.AddRange(profileTools);
         toolsWithMcp.AddRange(mcpManager.Tools);
-        return agentFactory.CreateAgentWithTools(toolsWithMcp, mm);
+        return agentFactory.CreateAgentWithTools(toolsWithMcp, mm, threadBaseContext);
+    }
+
+    private static OpenAI.Chat.ChatClient ResolveThreadChatClient(ToolProviderContext baseContext, ThreadConfiguration config)
+    {
+        if (string.IsNullOrWhiteSpace(config.Model))
+            return baseContext.ChatClient;
+
+        if (string.IsNullOrWhiteSpace(baseContext.Config.ApiKey))
+            return baseContext.ChatClient;
+
+        if (!Uri.TryCreate(baseContext.Config.EndPoint, UriKind.Absolute, out var endpoint))
+            return baseContext.ChatClient;
+
+        var openAIClient = new OpenAIClient(
+            new ApiKeyCredential(baseContext.Config.ApiKey),
+            new OpenAIClientOptions { Endpoint = endpoint });
+        return openAIClient.GetChatClient(config.Model);
+    }
+
+    private static ToolProviderContext CloneContextWithChatClient(
+        ToolProviderContext source,
+        OpenAI.Chat.ChatClient chatClient)
+    {
+        var cloned = new ToolProviderContext
+        {
+            Config = source.Config,
+            ChatClient = chatClient,
+            WorkspacePath = source.WorkspacePath,
+            BotPath = source.BotPath,
+            MemoryStore = source.MemoryStore,
+            SkillsLoader = source.SkillsLoader,
+            ApprovalService = source.ApprovalService,
+            PathBlacklist = source.PathBlacklist,
+            CronTools = source.CronTools,
+            McpClientManager = source.McpClientManager,
+            TraceCollector = source.TraceCollector,
+            ChannelClient = source.ChannelClient,
+            AcpExtensionProxy = source.AcpExtensionProxy,
+            AgentFileSystem = source.AgentFileSystem,
+            AutomationTaskDirectory = source.AutomationTaskDirectory,
+            RequireApprovalOutsideWorkspace = source.RequireApprovalOutsideWorkspace
+        };
+        cloned.DeferredToolRegistry = source.DeferredToolRegistry;
+        return cloned;
     }
 }

--- a/src/DotCraft.Core/Protocol/SessionService.cs
+++ b/src/DotCraft.Core/Protocol/SessionService.cs
@@ -867,11 +867,7 @@ public sealed class SessionService(
         thread.Configuration ??= new ThreadConfiguration();
         thread.Configuration.Mode = mode;
 
-        var agentMode = mode.Equals("plan", StringComparison.OrdinalIgnoreCase)
-            ? AgentMode.Plan
-            : AgentMode.Agent;
-        var mm = GetOrCreateModeManager(threadId, agentMode);
-        _threadAgents[threadId] = agentFactory.CreateAgentForMode(agentMode, mm);
+        _threadAgents[threadId] = await BuildAgentForConfigAsync(threadId, thread.Configuration, ct);
 
         await threadStore.SaveThreadAsync(thread, ct);
     }
@@ -1128,10 +1124,10 @@ public sealed class SessionService(
         if (!Uri.TryCreate(baseContext.Config.EndPoint, UriKind.Absolute, out var endpoint))
             return baseContext.ChatClient;
 
-        var openAIClient = new OpenAIClient(
+        var client = new OpenAIClient(
             new ApiKeyCredential(baseContext.Config.ApiKey),
             new OpenAIClientOptions { Endpoint = endpoint });
-        return openAIClient.GetChatClient(config.Model);
+        return client.GetChatClient(config.Model);
     }
 
     private static ToolProviderContext CloneContextWithChatClient(
@@ -1155,9 +1151,9 @@ public sealed class SessionService(
             AcpExtensionProxy = source.AcpExtensionProxy,
             AgentFileSystem = source.AgentFileSystem,
             AutomationTaskDirectory = source.AutomationTaskDirectory,
-            RequireApprovalOutsideWorkspace = source.RequireApprovalOutsideWorkspace
+            RequireApprovalOutsideWorkspace = source.RequireApprovalOutsideWorkspace,
+            DeferredToolRegistry = source.DeferredToolRegistry
         };
-        cloned.DeferredToolRegistry = source.DeferredToolRegistry;
         return cloned;
     }
 }

--- a/src/DotCraft.Core/Protocol/ThreadConfiguration.cs
+++ b/src/DotCraft.Core/Protocol/ThreadConfiguration.cs
@@ -29,6 +29,11 @@ public sealed class ThreadConfiguration
     public string[]? CustomTools { get; set; }
 
     /// <summary>
+    /// Optional per-thread model override. When empty, the workspace/global <c>AppConfig.Model</c> is used.
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
     /// When set, all tools for this thread operate on this workspace path
     /// instead of the AppServer's root workspace path.
     /// The thread is still registered under the AppServer's root workspace

--- a/src/DotCraft.Core/Resources/DashBoard.html
+++ b/src/DotCraft.Core/Resources/DashBoard.html
@@ -2288,6 +2288,8 @@ let settingsSetupMode = false;
 let settingsHasApiKey = true;
 let settingsDirty = false;
 let settingsActiveTab = 'workspace'; // 'workspace' | 'global' (setup mode only)
+let settingsDynamicModelOptions = null;
+let settingsDynamicModelError = '';
 
 // ─── HELPERS ──────────────────────────────────────────────────────────────────
 
@@ -2314,6 +2316,37 @@ function schemaGetValue(data, section, fieldKey) {
     }
   }
   return ciGet(obj, fieldKey);
+}
+
+function isDynamicModelField(field) {
+  if (!field || typeof field.key !== 'string') return false;
+  return field.key === 'Model' || field.key === 'ConsolidationModel';
+}
+
+async function loadDynamicModelOptions() {
+  settingsDynamicModelOptions = null;
+  settingsDynamicModelError = '';
+  try {
+    const res = await fetch(API + '/config/models', { credentials: 'same-origin' });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data || data.success !== true || !Array.isArray(data.models)) {
+      settingsDynamicModelOptions = [];
+      settingsDynamicModelError = (data && data.errorMessage) ? String(data.errorMessage) : 'Model list unavailable.';
+      return;
+    }
+
+    const ids = data.models
+      .map(m => {
+        if (!m) return '';
+        const id = (m.id !== undefined && m.id !== null) ? m.id : m.Id;
+        return id !== undefined && id !== null ? String(id).trim() : '';
+      })
+      .filter(Boolean);
+    settingsDynamicModelOptions = Array.from(new Set(ids)).sort((a, b) => a.localeCompare(b));
+  } catch (e) {
+    settingsDynamicModelOptions = [];
+    settingsDynamicModelError = (e && e.message) ? e.message : 'Model list unavailable.';
+  }
 }
 
 // Build a field element ID
@@ -2865,6 +2898,29 @@ function renderFormField(id, field, rawVal, scope, section, sourceBadge = '') {
     ${sourceBadge}
   </div>`;
 
+  if (isDynamicModelField(field)) {
+    const val = (rawVal !== undefined && rawVal !== null) ? String(rawVal) : '';
+    const dynamic = Array.isArray(settingsDynamicModelOptions) ? settingsDynamicModelOptions : null;
+    const dynamicAvailable = dynamic && dynamic.length > 0;
+    const dynamicHint = settingsDynamicModelError
+      ? `<div class="settings-hint">Model list unavailable: ${escapeHtml(settingsDynamicModelError)}</div>`
+      : '';
+
+    if (dynamicAvailable) {
+      const optionSet = new Set(dynamic);
+      if (val) optionSet.add(val);
+      const options = ['', ...Array.from(optionSet).sort((a, b) => a.localeCompare(b))].map(o => {
+        const label = o === '' ? emptyText : o;
+        const selected = o === val ? ' selected' : '';
+        return `<option value="${escapeHtml(o)}"${selected}>${escapeHtml(label)}</option>`;
+      }).join('');
+      return `<div class="settings-field" data-field-key="${escapeHtml(field.key)}">
+        ${headerHtml}
+        <select class="settings-select" id="${id}">${options}</select>${hint}${dynamicHint}
+      </div>`;
+    }
+  }
+
   if (field.type === 'bool') {
     let state = '';
     if (rawVal === true || rawVal === 'true') state = 'true';
@@ -3266,6 +3322,7 @@ let settingsWorkspacePath = '';
 
 // ─── REFRESH SETTINGS ─────────────────────────────────────────────────────────
 async function refreshSettings() {
+  await loadDynamicModelOptions();
   const data = await fetchJson('/config/edit');
   if (!data) {
     document.getElementById('settingsGlobalBody').innerHTML =

--- a/tests/DotCraft.Core.Tests/Protocol/SessionServiceSetThreadModeTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/SessionServiceSetThreadModeTests.cs
@@ -1,0 +1,155 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using DotCraft.Abstractions;
+using DotCraft.Agents;
+using DotCraft.Configuration;
+using DotCraft.Memory;
+using DotCraft.Protocol;
+using DotCraft.Security;
+using DotCraft.Sessions;
+using DotCraft.Skills;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace DotCraft.Tests.Sessions.Protocol;
+
+/// <summary>
+/// Regression: <see cref="SessionService.SetThreadModeAsync"/> must rebuild the per-thread agent via
+/// <see cref="SessionService"/> (same path as config updates) so <see cref="ThreadConfiguration.Model"/> is not lost.
+/// </summary>
+public sealed class SessionServiceSetThreadModeTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SessionServiceSetThreadModeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "SetThreadMode_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task SetThreadModeAsync_KeepsPerThreadChatClient_WhenModelOverrideIsSet()
+    {
+        var store = new ThreadStore(_tempDir);
+        var identity = new SessionIdentity
+        {
+            ChannelName = "test",
+            UserId = "u",
+            WorkspacePath = _tempDir
+        };
+
+        const string modelOverride = "gpt-per-thread-model-override";
+
+        await using var agentFactory = CreateAgentFactory();
+        var defaultAgent = agentFactory.CreateAgentForMode(AgentMode.Agent);
+        var svc = new SessionService(agentFactory, defaultAgent, store, new SessionGate());
+
+        var config = new ThreadConfiguration
+        {
+            Mode = "agent",
+            Model = modelOverride
+        };
+        var thread = await svc.CreateThreadAsync(identity, config);
+
+        await svc.SetThreadModeAsync(thread.Id, "plan");
+
+        var innerAfterModeSwitch = GetInnermostChatClient(GetCachedThreadAgent(svc, thread.Id));
+        Assert.NotNull(innerAfterModeSwitch);
+
+        var loaded = await store.LoadThreadAsync(thread.Id);
+        Assert.Equal("plan", loaded?.Configuration?.Mode);
+        Assert.Equal(modelOverride, loaded?.Configuration?.Model);
+
+        // Old bug: CreateAgentForMode ignored thread.Model — inner client matched the global default agent.
+        var defaultPlanAgent = agentFactory.CreateAgentForMode(AgentMode.Plan);
+        var innerDefaultPlan = GetInnermostChatClient(defaultPlanAgent);
+        Assert.NotSame(innerDefaultPlan, innerAfterModeSwitch);
+    }
+
+    private AgentFactory CreateAgentFactory()
+    {
+        var config = new AppConfig
+        {
+            ApiKey = "sk-test-not-used-for-network",
+            EndPoint = "https://127.0.0.1:9/v1"
+        };
+        var memory = new MemoryStore(_tempDir);
+        var skills = new SkillsLoader(_tempDir);
+        return new AgentFactory(
+            dotcraftPath: _tempDir,
+            workspacePath: _tempDir,
+            config: config,
+            memoryStore: memory,
+            skillsLoader: skills,
+            approvalService: new AutoApproveApprovalService(),
+            blacklist: null,
+            toolProviders: Array.Empty<IAgentToolProvider>());
+    }
+
+    private static AIAgent GetCachedThreadAgent(SessionService svc, string threadId)
+    {
+        var field = typeof(SessionService).GetField("_threadAgents", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        var dict = (ConcurrentDictionary<string, AIAgent>)field.GetValue(svc)!;
+        Assert.True(dict.TryGetValue(threadId, out var agent));
+        return agent;
+    }
+
+    private static IChatClient? GetInnermostChatClient(AIAgent agent)
+    {
+        var client = TryGetChatClientFromAgent(agent);
+        return UnwrapToInnermost(client);
+    }
+
+    private static IChatClient? TryGetChatClientFromAgent(AIAgent agent)
+    {
+        for (var t = agent.GetType(); t != null; t = t.BaseType)
+        {
+            foreach (var p in t.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (!typeof(IChatClient).IsAssignableFrom(p.PropertyType))
+                    continue;
+                if (p.GetIndexParameters().Length != 0)
+                    continue;
+                if (p.GetValue(agent) is IChatClient chat)
+                    return chat;
+            }
+        }
+
+        return null;
+    }
+
+    private static IChatClient? UnwrapToInnermost(IChatClient? client)
+    {
+        var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        while (client != null && seen.Add(client))
+        {
+            IChatClient? next = null;
+            var t = client.GetType();
+            foreach (var p in t.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (p.PropertyType != typeof(IChatClient) && !typeof(IChatClient).IsAssignableFrom(p.PropertyType))
+                    continue;
+                if (p.GetIndexParameters().Length != 0)
+                    continue;
+                if (p.GetValue(client) is IChatClient inner)
+                {
+                    next = inner;
+                    break;
+                }
+            }
+
+            if (next == null)
+                return client;
+            client = next;
+        }
+
+        return client;
+    }
+}


### PR DESCRIPTION
The PR introduces model catalog management with sound implementation:

Per-thread model support: SessionService.ResolveThreadChatClient correctly creates a thread-specific ChatClient and the cloned ToolProviderContext propagates it through all tool creation and agent building paths. The change in AgentFactory.BuildAgent (line 382) from _chatClient to ctx.ChatClient ensures the middleware pipeline uses the thread's selected model.

Frontend state management: Model selection properly disables send during catalog loading (modelLoading), includes the selected model in pendingWelcomeTurn, and applies it via thread/config/update before the first turn/start. Error handling rolls back UI state on failure with user-visible toast feedback.

IPC handler safety: The handleSafe wrapper correctly removes existing handlers before registration, preventing duplicate-handler errors on re-registration during workspace switches.

Null/error handling: ResolveThreadChatClient gracefully falls back to baseContext.ChatClient on missing/invalid configuration. Frontend config reads catch exceptions and fall back to defaults. parseModelOptions tolerates malformed payloads.