### PR TITLE
Add memory auto-consolidation feature to workspace configuration

### DIFF
--- a/desktop/src/main/ipcBridge.ts
+++ b/desktop/src/main/ipcBridge.ts
@@ -247,6 +247,7 @@ interface WorkspaceCoreConfigSnapshot {
   endPoint: string | null
   welcomeSuggestionsEnabled: boolean | null
   skillsSelfLearningEnabled: boolean | null
+  memoryAutoConsolidateEnabled: boolean | null
   defaultApprovalPolicy: 'default' | 'autoApprove' | null
 }
 
@@ -302,6 +303,7 @@ async function readCoreConfigSnapshot(configPath: string): Promise<WorkspaceCore
       endPoint: normalizeOptionalStringValue(parsed.EndPoint ?? parsed.endPoint),
       welcomeSuggestionsEnabled: readNestedBoolean(parsed, 'WelcomeSuggestions', 'Enabled'),
       skillsSelfLearningEnabled: readSkillsSelfLearningEnabled(parsed),
+      memoryAutoConsolidateEnabled: readNestedBoolean(parsed, 'Memory', 'AutoConsolidateEnabled'),
       defaultApprovalPolicy: readDefaultApprovalPolicy(parsed)
     }
   } catch (error) {
@@ -312,6 +314,7 @@ async function readCoreConfigSnapshot(configPath: string): Promise<WorkspaceCore
         endPoint: null,
         welcomeSuggestionsEnabled: null,
         skillsSelfLearningEnabled: null,
+        memoryAutoConsolidateEnabled: null,
         defaultApprovalPolicy: null
       }
     }
@@ -707,6 +710,7 @@ export function registerIpcHandlers(
             endPoint: null,
             welcomeSuggestionsEnabled: null,
             skillsSelfLearningEnabled: null,
+            memoryAutoConsolidateEnabled: null,
             defaultApprovalPolicy: null
           },
           userDefaults: await readCoreConfigSnapshot(path.join(os.homedir(), '.craft', 'config.json'))

--- a/desktop/src/main/tests/ipcBridge.test.ts
+++ b/desktop/src/main/tests/ipcBridge.test.ts
@@ -331,6 +331,9 @@ describe('registerIpcHandlers', () => {
       const pathText = String(filePath)
       if (pathText.includes('dotcraft')) {
         return JSON.stringify({
+          Memory: {
+            AutoConsolidateEnabled: true
+          },
           Skills: {
             SelfLearning: {
               Enabled: true
@@ -339,6 +342,9 @@ describe('registerIpcHandlers', () => {
         })
       }
       return JSON.stringify({
+        Memory: {
+          AutoConsolidateEnabled: false
+        },
         Skills: {
           SelfLearning: {
             Enabled: false
@@ -379,8 +385,8 @@ describe('registerIpcHandlers', () => {
 
     const result = await handlers.get('workspace-config:get-core')?.({})
     expect(result).toMatchObject({
-      workspace: { skillsSelfLearningEnabled: true },
-      userDefaults: { skillsSelfLearningEnabled: false }
+      workspace: { skillsSelfLearningEnabled: true, memoryAutoConsolidateEnabled: true },
+      userDefaults: { skillsSelfLearningEnabled: false, memoryAutoConsolidateEnabled: false }
     })
   })
 

--- a/desktop/src/preload/api.d.ts
+++ b/desktop/src/preload/api.d.ts
@@ -343,6 +343,7 @@ declare global {
             endPoint: string | null
             welcomeSuggestionsEnabled: boolean | null
             skillsSelfLearningEnabled: boolean | null
+            memoryAutoConsolidateEnabled: boolean | null
             defaultApprovalPolicy: 'default' | 'autoApprove' | null
           }
           userDefaults: {
@@ -350,6 +351,7 @@ declare global {
             endPoint: string | null
             welcomeSuggestionsEnabled: boolean | null
             skillsSelfLearningEnabled: boolean | null
+            memoryAutoConsolidateEnabled: boolean | null
             defaultApprovalPolicy: 'default' | 'autoApprove' | null
           }
         }>

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -444,6 +444,7 @@ const api = {
         endPoint: string | null
         welcomeSuggestionsEnabled: boolean | null
         skillsSelfLearningEnabled: boolean | null
+        memoryAutoConsolidateEnabled: boolean | null
         defaultApprovalPolicy: 'default' | 'autoApprove' | null
       }
       userDefaults: {
@@ -451,6 +452,7 @@ const api = {
         endPoint: string | null
         welcomeSuggestionsEnabled: boolean | null
         skillsSelfLearningEnabled: boolean | null
+        memoryAutoConsolidateEnabled: boolean | null
         defaultApprovalPolicy: 'default' | 'autoApprove' | null
       }
     }> {

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -750,10 +750,17 @@ export function App(): JSX.Element {
           case 'system/event': {
             const tid = (p.threadId as string | undefined) ?? ''
             if (!shouldUpdateActiveConversation(tid)) break
-            conv.onSystemEvent((p.kind as string) ?? '', {
+            const kind = (p.kind as string) ?? ''
+            conv.onSystemEvent(kind, {
               tokenCount: typeof p.tokenCount === 'number' ? (p.tokenCount as number) : null,
               percentLeft: typeof p.percentLeft === 'number' ? (p.percentLeft as number) : null
             })
+            if (kind === 'consolidationFailed') {
+              addToast(
+                (p.message as string | undefined) ?? translate(localeRef.current, 'systemNotice.consolidationFailed.message'),
+                'warning'
+              )
+            }
             break
           }
 

--- a/desktop/src/renderer/components/settings/SettingsView.tsx
+++ b/desktop/src/renderer/components/settings/SettingsView.tsx
@@ -89,6 +89,7 @@ interface WorkspaceCoreConfig {
   endPoint: string | null
   welcomeSuggestionsEnabled: boolean | null
   skillsSelfLearningEnabled: boolean | null
+  memoryAutoConsolidateEnabled: boolean | null
   defaultApprovalPolicy: VisibleApprovalPolicy | null
 }
 
@@ -102,6 +103,7 @@ const EMPTY_WORKSPACE_CORE_CONFIG: WorkspaceCoreConfig = {
   endPoint: null,
   welcomeSuggestionsEnabled: null,
   skillsSelfLearningEnabled: null,
+  memoryAutoConsolidateEnabled: null,
   defaultApprovalPolicy: null
 }
 
@@ -123,6 +125,10 @@ function normalizeWorkspaceCoreConfig(value: unknown): WorkspaceCoreConfig {
     skillsSelfLearningEnabled:
       typeof source.skillsSelfLearningEnabled === 'boolean'
         ? source.skillsSelfLearningEnabled
+        : null,
+    memoryAutoConsolidateEnabled:
+      typeof source.memoryAutoConsolidateEnabled === 'boolean'
+        ? source.memoryAutoConsolidateEnabled
         : null,
     defaultApprovalPolicy: normalizeVisibleApprovalPolicy(source.defaultApprovalPolicy)
   }
@@ -600,6 +606,7 @@ export function SettingsView({
     endPoint: null,
     welcomeSuggestionsEnabled: null,
     skillsSelfLearningEnabled: null,
+    memoryAutoConsolidateEnabled: null,
     defaultApprovalPolicy: null
   })
   const [userDefaultCore, setUserDefaultCore] = useState<WorkspaceCoreConfig>({
@@ -607,6 +614,7 @@ export function SettingsView({
     endPoint: null,
     welcomeSuggestionsEnabled: null,
     skillsSelfLearningEnabled: null,
+    memoryAutoConsolidateEnabled: null,
     defaultApprovalPolicy: null
   })
   const [apiKeyOverrideActive, setApiKeyOverrideActive] = useState(true)
@@ -619,6 +627,8 @@ export function SettingsView({
   const [selfLearningEnabled, setSelfLearningEnabled] = useState(true)
   const [applyingSelfLearning, setApplyingSelfLearning] = useState(false)
   const [selfLearningRestartPending, setSelfLearningRestartPending] = useState(false)
+  const [memoryAutoConsolidateEnabled, setMemoryAutoConsolidateEnabled] = useState(true)
+  const [applyingMemoryAutoConsolidate, setApplyingMemoryAutoConsolidate] = useState(false)
   const [defaultApprovalPolicy, setDefaultApprovalPolicy] = useState<VisibleApprovalPolicy>('default')
   const [applyingDefaultApprovalPolicy, setApplyingDefaultApprovalPolicy] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -694,6 +704,11 @@ export function SettingsView({
       core.userDefaults.skillsSelfLearningEnabled ??
       true
     setSelfLearningEnabled(resolvedSelfLearningEnabled)
+    const resolvedMemoryAutoConsolidateEnabled =
+      core.workspace.memoryAutoConsolidateEnabled ??
+      core.userDefaults.memoryAutoConsolidateEnabled ??
+      true
+    setMemoryAutoConsolidateEnabled(resolvedMemoryAutoConsolidateEnabled)
     const resolvedDefaultApprovalPolicy =
       core.workspace.defaultApprovalPolicy ??
       core.userDefaults.defaultApprovalPolicy ??
@@ -784,6 +799,31 @@ export function SettingsView({
       }
     },
     [reloadWorkspaceCore, selfLearningEnabled, t]
+  )
+
+  const handleMemoryAutoConsolidateToggle = useCallback(
+    async (checked: boolean): Promise<void> => {
+      const previous = memoryAutoConsolidateEnabled
+      setMemoryAutoConsolidateEnabled(checked)
+      setApplyingMemoryAutoConsolidate(true)
+      try {
+        const result = await window.api.appServer.sendRequest('workspace/config/update', {
+          memoryAutoConsolidateEnabled: checked
+        }) as { memoryAutoConsolidateEnabled?: boolean | null }
+        const persisted = typeof result?.memoryAutoConsolidateEnabled === 'boolean'
+          ? result.memoryAutoConsolidateEnabled
+          : checked
+        setMemoryAutoConsolidateEnabled(persisted)
+        await reloadWorkspaceCore()
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        setMemoryAutoConsolidateEnabled(previous)
+        addToast(t('settings.personalization.longTermMemorySaveFailed', { error: msg }), 'error')
+      } finally {
+        setApplyingMemoryAutoConsolidate(false)
+      }
+    },
+    [memoryAutoConsolidateEnabled, reloadWorkspaceCore, t]
   )
 
   const handleDefaultApprovalPolicyChange = useCallback(
@@ -2454,6 +2494,20 @@ export function SettingsView({
                         aria-label={t('settings.personalization.selfLearning')}
                         onChange={(checked) => {
                           void handleSelfLearningToggle(checked)
+                        }}
+                      />
+                    }
+                  />
+                  <SettingsRow
+                    label={t('settings.personalization.longTermMemory')}
+                    description={t('settings.personalization.longTermMemoryHint')}
+                    control={
+                      <PillSwitch
+                        checked={memoryAutoConsolidateEnabled}
+                        disabled={applyingMemoryAutoConsolidate}
+                        aria-label={t('settings.personalization.longTermMemory')}
+                        onChange={(checked) => {
+                          void handleMemoryAutoConsolidateToggle(checked)
                         }}
                       />
                     }

--- a/desktop/src/renderer/hooks/useSettingsWorkspaceConfigChangeEffects.ts
+++ b/desktop/src/renderer/hooks/useSettingsWorkspaceConfigChangeEffects.ts
@@ -46,6 +46,7 @@ export function useSettingsWorkspaceConfigChangeEffects({
     const workspaceCoreChanged =
       llmCoreChanged ||
       changedRegions.has('welcomeSuggestions') ||
+      changedRegions.has('memory') ||
       changedRegions.has(WORKSPACE_DEFAULT_APPROVAL_POLICY_REGION)
 
     if (workspaceCoreChanged) {

--- a/desktop/src/renderer/stores/conversationStore.ts
+++ b/desktop/src/renderer/stores/conversationStore.ts
@@ -374,7 +374,8 @@ const SYSTEM_LABELS: Record<string, string | null> = {
   compacted: null,
   compactFailed: null,
   compactSkipped: null,
-  consolidated: null
+  consolidated: null,
+  consolidationFailed: null
 }
 
 function computeSeverity(tokens: number, snapshot: {

--- a/desktop/src/renderer/tests/SettingsView.selfLearning.test.tsx
+++ b/desktop/src/renderer/tests/SettingsView.selfLearning.test.tsx
@@ -29,6 +29,7 @@ describe('SettingsView self-learning settings', () => {
         endPoint: null,
         welcomeSuggestionsEnabled: null,
         skillsSelfLearningEnabled: false,
+        memoryAutoConsolidateEnabled: false,
         defaultApprovalPolicy: 'default'
       },
       userDefaults: {
@@ -36,6 +37,7 @@ describe('SettingsView self-learning settings', () => {
         endPoint: null,
         welcomeSuggestionsEnabled: null,
         skillsSelfLearningEnabled: null,
+        memoryAutoConsolidateEnabled: null,
         defaultApprovalPolicy: null
       }
     }
@@ -48,6 +50,10 @@ describe('SettingsView self-learning settings', () => {
         if (typeof params?.defaultApprovalPolicy === 'string') {
           core.workspace.defaultApprovalPolicy = params.defaultApprovalPolicy
           return { defaultApprovalPolicy: core.workspace.defaultApprovalPolicy }
+        }
+        if (typeof params?.memoryAutoConsolidateEnabled === 'boolean') {
+          core.workspace.memoryAutoConsolidateEnabled = params.memoryAutoConsolidateEnabled
+          return { memoryAutoConsolidateEnabled: core.workspace.memoryAutoConsolidateEnabled }
         }
         core.workspace.skillsSelfLearningEnabled = params?.skillsSelfLearningEnabled === true
         return { skillsSelfLearningEnabled: core.workspace.skillsSelfLearningEnabled }
@@ -134,6 +140,7 @@ describe('SettingsView self-learning settings', () => {
         endPoint: null,
         welcomeSuggestionsEnabled: null,
         skillsSelfLearningEnabled: null,
+        memoryAutoConsolidateEnabled: null,
         defaultApprovalPolicy: null
       },
       userDefaults: {
@@ -141,6 +148,7 @@ describe('SettingsView self-learning settings', () => {
         endPoint: null,
         welcomeSuggestionsEnabled: null,
         skillsSelfLearningEnabled: null,
+        memoryAutoConsolidateEnabled: null,
         defaultApprovalPolicy: null
       }
     })
@@ -151,6 +159,23 @@ describe('SettingsView self-learning settings', () => {
     const toggle = await screen.findByRole('switch', { name: 'Enable self-learning' })
 
     expect(toggle).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('saves long-term memory toggle without restart banner', async () => {
+    renderView()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Personalization' }))
+    const toggle = await screen.findByRole('switch', { name: 'Enable long-term memory' })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(toggle)
+
+    await waitFor(() => {
+      expect(appServerSendRequest).toHaveBeenCalledWith('workspace/config/update', {
+        memoryAutoConsolidateEnabled: true
+      })
+    })
+    expect(screen.queryByText('Self-learning changes are saved. Restart AppServer to apply them.')).not.toBeInTheDocument()
   })
 
   it('warns and saves full access default approval policy', async () => {

--- a/desktop/src/renderer/tests/SettingsView.workspaceCoreRead.test.ts
+++ b/desktop/src/renderer/tests/SettingsView.workspaceCoreRead.test.ts
@@ -12,6 +12,7 @@ describe('SettingsView workspace core readers', () => {
         endPoint: null,
         welcomeSuggestionsEnabled: null,
         skillsSelfLearningEnabled: null,
+        memoryAutoConsolidateEnabled: null,
         defaultApprovalPolicy: null
       },
       userDefaults: {
@@ -19,6 +20,7 @@ describe('SettingsView workspace core readers', () => {
         endPoint: null,
         welcomeSuggestionsEnabled: null,
         skillsSelfLearningEnabled: null,
+        memoryAutoConsolidateEnabled: null,
         defaultApprovalPolicy: null
       }
     })
@@ -40,10 +42,18 @@ describe('SettingsView workspace core readers', () => {
     ).rejects.toThrow('boom')
   })
 
-  it('normalizes self-learning config from workspace and user defaults', async () => {
+  it('normalizes personalization config from workspace and user defaults', async () => {
     const getCore = vi.fn<() => Promise<unknown>>().mockResolvedValue({
-      workspace: { skillsSelfLearningEnabled: true, defaultApprovalPolicy: 'autoApprove' },
-      userDefaults: { skillsSelfLearningEnabled: false, defaultApprovalPolicy: 'default' }
+      workspace: {
+        skillsSelfLearningEnabled: true,
+        memoryAutoConsolidateEnabled: false,
+        defaultApprovalPolicy: 'autoApprove'
+      },
+      userDefaults: {
+        skillsSelfLearningEnabled: false,
+        memoryAutoConsolidateEnabled: true,
+        defaultApprovalPolicy: 'default'
+      }
     })
 
     await expect(
@@ -56,6 +66,7 @@ describe('SettingsView workspace core readers', () => {
         endPoint: null,
         welcomeSuggestionsEnabled: null,
         skillsSelfLearningEnabled: true,
+        memoryAutoConsolidateEnabled: false,
         defaultApprovalPolicy: 'autoApprove'
       },
       userDefaults: {
@@ -63,6 +74,7 @@ describe('SettingsView workspace core readers', () => {
         endPoint: null,
         welcomeSuggestionsEnabled: null,
         skillsSelfLearningEnabled: false,
+        memoryAutoConsolidateEnabled: true,
         defaultApprovalPolicy: 'default'
       }
     })

--- a/desktop/src/renderer/tests/conversationStore.test.ts
+++ b/desktop/src/renderer/tests/conversationStore.test.ts
@@ -501,6 +501,14 @@ describe('system events', () => {
     expect(s().systemLabel).toBeNull()
   })
 
+  it('clears label on "consolidationFailed" event', () => {
+    s().onTurnStarted(makeTurn())
+    s().onSystemEvent('consolidating')
+    expect(s().systemLabel).toBe('systemStatus.consolidating')
+    s().onSystemEvent('consolidationFailed')
+    expect(s().systemLabel).toBeNull()
+  })
+
   it('ignores unknown system event kinds', () => {
     s().onTurnStarted(makeTurn())
     s().onSystemEvent('unknown-event-xyz')

--- a/desktop/src/renderer/tests/useSettingsWorkspaceConfigChangeEffects.test.tsx
+++ b/desktop/src/renderer/tests/useSettingsWorkspaceConfigChangeEffects.test.tsx
@@ -205,6 +205,33 @@ describe('useSettingsWorkspaceConfigChangeEffects', () => {
     expect(onExternalLlmChangeNotice).not.toHaveBeenCalled()
   })
 
+  it('reloads workspace core when memory config changes', async () => {
+    const reloadWorkspaceCore = vi.fn()
+    const { rerender } = render(
+      <HookHost
+        change={null}
+        changeSeq={0}
+        reloadWorkspaceCore={reloadWorkspaceCore}
+      />
+    )
+
+    rerender(
+      <HookHost
+        change={{
+          source: 'workspace/config/update',
+          regions: ['memory'],
+          changedAt: '2026-04-19T10:15:03Z'
+        }}
+        changeSeq={1}
+        reloadWorkspaceCore={reloadWorkspaceCore}
+      />
+    )
+
+    await waitFor(() => {
+      expect(reloadWorkspaceCore).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('reloads workspace core when default approval policy changes', async () => {
     const reloadWorkspaceCore = vi.fn()
     const { rerender } = render(

--- a/desktop/src/shared/locales/catalog.ts
+++ b/desktop/src/shared/locales/catalog.ts
@@ -74,6 +74,10 @@ const MESSAGES_EN = {
   'settings.personalization.selfLearningRestartBannerRemote':
     'Self-learning changes are saved. Restart the remote AppServer to apply them.',
   'settings.personalization.selfLearningRestartButton': 'Restart now',
+  'settings.personalization.longTermMemory': 'Enable long-term memory',
+  'settings.personalization.longTermMemoryHint':
+    'Let DotCraft progressively accumulate facts about you and the workspace so future sessions can reference them.',
+  'settings.personalization.longTermMemorySaveFailed': 'Failed to save long-term memory setting: {{error}}',
   'settings.permissions.description':
     'Choose the default approval behavior for new threads in this workspace. Channels without per-thread controls use this setting.',
   'settings.permissions.workspaceDefault.label': 'Workspace default permissions',
@@ -774,6 +778,7 @@ const MESSAGES_EN = {
   'contextRing.tooltip.autoCompact': 'Auto-compact triggers at {{percent}}%',
   'systemStatus.compacting': 'Auto-compacting context',
   'systemStatus.consolidating': 'Consolidating memory',
+  'systemNotice.consolidationFailed.message': 'Long-term memory consolidation failed.',
   'systemNotice.compacted.title': 'Context compacted',
   'systemNotice.compacted.auto': 'Auto-compacted',
   'systemNotice.compacted.reactive': 'Recovered from context overflow',
@@ -1705,6 +1710,10 @@ const MESSAGES_ZH: Record<MessageId, string> = {
   'settings.personalization.selfLearningRestartBannerRemote':
     '自我学习设置已保存。请重启远程 AppServer 使其生效。',
   'settings.personalization.selfLearningRestartButton': '立即重启',
+  'settings.personalization.longTermMemory': '启用长期记忆',
+  'settings.personalization.longTermMemoryHint':
+    '让 DotCraft 在对话期间逐步积累关于你和工作区的事实，下次会话仍可被引用。',
+  'settings.personalization.longTermMemorySaveFailed': '保存长期记忆设置失败：{{error}}',
   'settings.permissions.description':
     '选择此工作区中新会话的默认审批行为。没有单会话选项的渠道会使用此设置。',
   'settings.permissions.workspaceDefault.label': '工作区默认权限',
@@ -2319,6 +2328,7 @@ const MESSAGES_ZH: Record<MessageId, string> = {
   'contextRing.tooltip.autoCompact': '达到 {{percent}}% 时自动压缩',
   'systemStatus.compacting': '正在自动压缩上下文',
   'systemStatus.consolidating': '正在整理记忆',
+  'systemNotice.consolidationFailed.message': '长期记忆整理失败。',
   'systemNotice.compacted.title': '上下文已压缩',
   'systemNotice.compacted.auto': '自动压缩完成',
   'systemNotice.compacted.reactive': '已在溢出后恢复',

--- a/docs/en/reference/config.md
+++ b/docs/en/reference/config.md
@@ -18,6 +18,13 @@ This page collects configuration fields in one place. For first-time setup, read
 | `DebugMode` | Prints untruncated tool arguments in the console | `false` |
 | `EnabledTools` | Globally enabled tool names. Empty enables all tools | `[]` |
 
+## Memory
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `Memory.AutoConsolidateEnabled` | Enables automatic long-term memory consolidation | `true` |
+| `Memory.ConsolidateEveryNTurns` | Successful turns per thread between long-term memory consolidation attempts | `5` |
+
 ## Compaction
 
 | Field | Description | Default |
@@ -37,7 +44,6 @@ This page collects configuration fields in one place. For first-time setup, read
 | `Compaction.MicrocompactTriggerCount` | Compressible tool-result count that triggers micro-compaction | `30` |
 | `Compaction.MicrocompactKeepRecent` | Recent tool results kept during micro-compaction | `8` |
 | `Compaction.MicrocompactGapMinutes` | Also triggers after this many minutes since last assistant message; `0` disables it | `20` |
-| `Compaction.MemoryConsolidationPrefixTokens` | Prefix size that triggers memory consolidation | `20000` |
 | `Compaction.MaxConsecutiveFailures` | Consecutive failures before circuit breaking compaction | `3` |
 
 ## Reasoning

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -18,6 +18,13 @@
 | `DebugMode` | 控制台不截断工具调用参数输出 | `false` |
 | `EnabledTools` | 全局启用的工具名称列表，为空时启用所有工具 | `[]` |
 
+## Memory
+
+| 配置项 | 说明 | 默认值 |
+|--------|------|--------|
+| `Memory.AutoConsolidateEnabled` | 启用长期记忆自动沉淀 | `true` |
+| `Memory.ConsolidateEveryNTurns` | 每个线程成功完成多少轮后触发一次长期记忆沉淀 | `5` |
+
 ## Compaction
 
 | 配置项 | 说明 | 默认值 |
@@ -37,7 +44,6 @@
 | `Compaction.MicrocompactTriggerCount` | 可压缩工具结果数量达到该值时触发微压缩 | `30` |
 | `Compaction.MicrocompactKeepRecent` | 微压缩时保留的最近工具结果数 | `8` |
 | `Compaction.MicrocompactGapMinutes` | 距离上次助理消息超过该分钟数也触发微压缩；`0` 表示禁用 | `20` |
-| `Compaction.MemoryConsolidationPrefixTokens` | 当前缀超过此 Token 数时触发记忆整合 | `20000` |
 | `Compaction.MaxConsecutiveFailures` | 连续失败次数达到该值时熔断 | `3` |
 
 ## Reasoning

--- a/samples/skills/dev-guide/SKILL.md
+++ b/samples/skills/dev-guide/SKILL.md
@@ -65,6 +65,8 @@ Use `[Description("...")]` on the method and on parameters for tool and paramete
 
 Tool argument streaming is enabled for every tool by default: AppServer clients receive `item/toolCall/argumentsDelta` notifications as the model fills in the arguments JSON, and the TUI/Desktop render per-tool live previews. If a tool must ship with a single atomic payload (for example because it proxies arguments to another process that cannot consume partial JSON, or because the arguments are sensitive), opt out by annotating the method with `[StreamArguments(false)]`; clients will then only see `item/started` followed by `item/completed` with no deltas. Omit the attribute to keep streaming enabled.
 
+File mutation tools that perform read-modify-write must serialize per canonical path with `PathAsyncMutex.AcquireAsync` (or `AcquireKeyAsync` for virtual filesystems) because model tool calls can run concurrently. This prevents Windows sharing violations and lost updates. A stricter read-before-write stale-check can be added later if the tool contract needs it.
+
 ### Language Preference
 
 - **Code comments**: English

--- a/specs/appserver-protocol.md
+++ b/specs/appserver-protocol.md
@@ -1629,9 +1629,9 @@ Emitted when a system-level maintenance operation occurs during a Turn's post-pr
 | Field | Type | Description |
 |-------|------|-------------|
 | `threadId` | string | Parent thread. |
-| `turnId` | string | Active turn. |
-| `kind` | string | Event kind. One of: `"compactWarning"`, `"compactError"`, `"compacting"`, `"compacted"`, `"compactSkipped"`, `"compactFailed"`, `"consolidating"`, `"consolidated"`. |
-| `message` | string? | Human-readable description (or machine-readable failure reason on `compactSkipped` / `compactFailed`). May be null. |
+| `turnId` | string? | Active turn. May be null for asynchronous thread-scoped maintenance events such as `consolidated` and `consolidationFailed`. |
+| `kind` | string | Event kind. One of: `"compactWarning"`, `"compactError"`, `"compacting"`, `"compacted"`, `"compactSkipped"`, `"compactFailed"`, `"consolidating"`, `"consolidated"`, `"consolidationFailed"`. |
+| `message` | string? | Human-readable description (or machine-readable failure reason on `compactSkipped` / `compactFailed` / `consolidationFailed`). May be null. |
 | `percentLeft` | number? | Fraction of the effective context window still unused (`0.0`-`1.0`). Populated for compaction-related events. |
 | `tokenCount` | number? | Current estimated prompt token usage. Populated for compaction-related events. |
 
@@ -1645,8 +1645,9 @@ Emitted when a system-level maintenance operation occurs during a Turn's post-pr
 | `compacted` | Compaction completed successfully. Token tracker has been reset. |
 | `compactSkipped` | Compaction was evaluated but not executed (below threshold, nothing new to summarize, or circuit breaker tripped). |
 | `compactFailed` | Compaction attempted but failed (LLM error, cancellation). Repeated failures trip the circuit breaker. |
-| `consolidating` | Memory consolidation is starting (fire-and-forget, driven by the compaction pipeline). |
+| `consolidating` | Memory consolidation is starting (fire-and-forget, driven by Session Core after a configured number of successful Turns). |
 | `consolidated` | Memory consolidation completed successfully. MEMORY.md / HISTORY.md have been updated. |
+| `consolidationFailed` | Memory consolidation failed. Clients should dismiss any active consolidation status and may surface `message`. |
 
 **Emission rules**:
 
@@ -1654,7 +1655,7 @@ Emitted when a system-level maintenance operation occurs during a Turn's post-pr
 - Threshold advisory events (`compactWarning`, `compactError`) fire when token usage crosses a threshold but auto-compaction has not yet been triggered.
 - Auto-compaction is a synchronous pair: `compacting` → one of `compacted` / `compactSkipped` / `compactFailed`.
 - Reactive compaction fires on the Turn's error path when the model rejects a request with `prompt_too_long` / `context_length_exceeded`. The Turn still fails, but `compacting` and its terminal event are emitted first so UIs know the history was repaired before the user retries.
-- Consolidation is fire-and-forget after a successful compaction; the Turn completes without awaiting it. Clients see `consolidating` / `consolidated` events asynchronously.
+- Memory consolidation is fire-and-forget after a configured number of successful Turns; it is independent from compaction and the Turn completes without awaiting it. The start event is `consolidating`; the terminal event is either `consolidated` or `consolidationFailed`. See [Memory Consolidation](memory-consolidation.md) for the design contract.
 - Clients that do not need system maintenance status can opt out via `optOutNotificationMethods: ["system/event"]` during `initialize`.
 - On a successful `compacted` event (auto or reactive trigger), Session Core additionally persists a `SystemNotice` SessionItem (kind = `"compacted"`) into the current turn and emits the normal `item/started` + `item/completed` pair for it. This gives clients a persistent timeline marker that survives thread reload, alongside the transient `system/event` notification used to drive toast/status-line UX. See [Session Core](session-core.md#systemnotice) for the payload schema.
 
@@ -4165,6 +4166,7 @@ Update workspace-level config values.
 | `endPoint` | string \| null | no | Workspace API endpoint. `null` or empty removes the `EndPoint` key. |
 | `welcomeSuggestionsEnabled` | boolean \| null | no | Workspace-level override for personalized welcome suggestions. `true` enables, `false` disables, and `null` removes the explicit override so server defaults apply. |
 | `skillsSelfLearningEnabled` | boolean \| null | no | Workspace-level override for `Skills.SelfLearning.Enabled`. `true` enables the SkillManage tool surface and skill-authoring built-in skill, `false` disables, and `null` removes the explicit override so server defaults apply (`true` by default). Takes effect on next AppServer restart (`Skills.SelfLearning.Enabled` is a `ProcessRestart` field). |
+| `memoryAutoConsolidateEnabled` | boolean \| null | no | Workspace-level override for `Memory.AutoConsolidateEnabled`. `true` enables turn-count-based long-term memory consolidation, `false` disables it, and `null` removes the explicit override so server defaults apply (`true` by default). Takes effect for future successful turns without restart. |
 | `defaultApprovalPolicy` | string \| null | no | Workspace default approval policy for threads whose `ThreadConfiguration.approvalPolicy` is `default` or unset. Supported values are `default` and `autoApprove`; `null` removes the explicit workspace override so server defaults apply. |
 
 **Result**:
@@ -4176,6 +4178,7 @@ Update workspace-level config values.
   "endPoint": "https://example.com/v1",
   "welcomeSuggestionsEnabled": true,
   "skillsSelfLearningEnabled": true,
+  "memoryAutoConsolidateEnabled": true,
   "defaultApprovalPolicy": "default"
 }
 ```
@@ -4193,11 +4196,12 @@ If `model` is removed, the result returns:
 - This method updates **workspace default** only, not any active thread state.
 - Clients that need immediate effect in a running thread should additionally call `thread/config/update`.
 - Server preserves unrelated configuration state.
-- At least one of `model`, `apiKey`, `endPoint`, `welcomeSuggestionsEnabled`, `skillsSelfLearningEnabled`, or `defaultApprovalPolicy` must be provided.
+- At least one of `model`, `apiKey`, `endPoint`, `welcomeSuggestionsEnabled`, `skillsSelfLearningEnabled`, `memoryAutoConsolidateEnabled`, or `defaultApprovalPolicy` must be provided.
 - Key matching is case-insensitive and normalized in-place (`Model`, `ApiKey`, `EndPoint`).
 - When `skillsSelfLearningEnabled` is provided, the server writes the boolean to the nested `Skills.SelfLearning.Enabled` key. Setting it to `null` removes the leaf, and the server prunes empty `Skills.SelfLearning` / `Skills` objects when no other keys remain.
+- When `memoryAutoConsolidateEnabled` is provided, the server writes the boolean to `Memory.AutoConsolidateEnabled`. Setting it to `null` removes the leaf, and the server prunes the empty `Memory` object when no other keys remain.
 - When `defaultApprovalPolicy` is provided, the server writes the value to `Permissions.DefaultApprovalPolicy`. Setting it to `null` removes the leaf, and the server prunes the empty `Permissions` object when no other keys remain.
-- On success, the server emits `workspace/configChanged` (see [Section 24.5](#245-workspaceconfigchanged)) with `source: "workspace/config/update"` and one or more regions from `workspace.model`, `workspace.apiKey`, `workspace.endpoint`, `welcomeSuggestions`, `skills`, `workspace.defaultApprovalPolicy`.
+- On success, the server emits `workspace/configChanged` (see [Section 24.5](#245-workspaceconfigchanged)) with `source: "workspace/config/update"` and one or more regions from `workspace.model`, `workspace.apiKey`, `workspace.endpoint`, `welcomeSuggestions`, `skills`, `memory`, `workspace.defaultApprovalPolicy`.
 
 ### 25.4 Capability Advertisement
 
@@ -4236,6 +4240,7 @@ Server notification emitted after a successful workspace configuration write.
 | `workspace.endpoint` | `workspace/config/update` |
 | `welcomeSuggestions` | `workspace/config/update` |
 | `skills` | `skills/setEnabled`, `workspace/config/update` |
+| `memory` | `workspace/config/update` |
 | `workspace.defaultApprovalPolicy` | `workspace/config/update` |
 | `mcp` | `mcp/upsert`, `mcp/remove` |
 | `externalChannel` | `externalChannel/upsert`, `externalChannel/remove` |

--- a/specs/hub-architecture.md
+++ b/specs/hub-architecture.md
@@ -179,7 +179,7 @@ Each WorkspaceRuntime contains:
 - **Paths**: `DotCraftPaths` (workspace root + `.craft/` path).
 - **Configuration**: `AppConfig` loaded from the workspace's `.craft/config.json` merged with global `~/.craft/config.json`.
 - **Persistence**: `ThreadStore`, `MemoryStore`, `ApprovalStore`, `PlanStore` — all rooted at the workspace's `.craft/`.
-- **Agent stack**: `AgentFactory`, `AgentRunner`, `Context.Compaction.CompactionPipeline`, `MemoryConsolidator`.
+- **Agent stack**: `AgentFactory`, `AgentRunner`, `Context.Compaction.CompactionPipeline`, `MemoryConsolidator`. Memory consolidation is a Session Core maintenance workflow independent from context compaction; see [Memory Consolidation](memory-consolidation.md).
 - **Session**: `SessionService`, `SessionGate`.
 - **Scheduling**: `CronService`, `HeartbeatService`.
 - **Skills and tools**: `SkillsLoader`, `CustomCommandLoader`, tool providers collected per-workspace config and enabled modules.

--- a/specs/memory-consolidation.md
+++ b/specs/memory-consolidation.md
@@ -1,0 +1,149 @@
+# DotCraft Memory Consolidation Design Specification
+
+| Field | Value |
+|-------|-------|
+| **Version** | 0.1.0 |
+| **Status** | Draft |
+| **Date** | 2026-04-29 |
+| **Parent Specs** | [Session Core](session-core.md), [AppServer Protocol](appserver-protocol.md) |
+
+Purpose: Define DotCraft's long-term memory consolidation flow. Memory consolidation is an independent persistence workflow for durable user and workspace knowledge. It is not a context compaction mechanism and does not depend on `CompactionPipeline`.
+
+## 1. Scope
+
+Memory consolidation turns completed conversation history into durable workspace memory.
+
+In scope:
+
+- Updating `MEMORY.md` with structured long-term facts.
+- Appending `HISTORY.md` with timestamped, grep-searchable event summaries.
+- Defining when consolidation runs and what conversation history it may inspect.
+- Defining failure, configuration, and user-facing control semantics.
+
+Out of scope:
+
+- Short-term context compaction and token-pressure recovery.
+- Provider prompt-cache behavior.
+- Vector retrieval, semantic indexes, or cross-workspace memory sharing.
+- Exact prompts, model-specific output formatting, and code-level implementation details.
+
+## 2. Core Concepts
+
+| Concept | Definition |
+|---------|------------|
+| **Short-term Compaction** | A context-window management workflow that reduces model-visible history so future model calls fit within token limits. |
+| **Long-term Memory Consolidation** | A persistence workflow that extracts durable facts and events from completed conversation history. |
+| **`MEMORY.md`** | The structured long-term memory file. It should contain stable facts about the user, workspace, preferences, and recurring project context. |
+| **`HISTORY.md`** | The append-only event log. It should contain compact timestamped paragraphs useful for search and audit. |
+| **Consolidation Window** | The conversation history snapshot given to the consolidation model for one consolidation attempt. |
+
+Short-term compaction and long-term memory consolidation may observe similar conversation content, but they optimize for different outcomes. Compaction protects the next model call. Consolidation improves future sessions by preserving durable knowledge.
+
+## 3. Triggering Model
+
+Consolidation runs after successful turns, using a simple per-thread counter:
+
+- Each successfully completed turn increments the thread's consolidation counter.
+- When the counter reaches the configured interval, DotCraft schedules a background consolidation task and resets the counter.
+- Failed or cancelled turns do not increment the counter and do not reset it.
+- Clearing or deleting a thread clears that thread's consolidation counter.
+
+`CompactionPipeline` does not trigger consolidation. A compaction attempt, success, failure, or circuit-breaker state must not affect whether memory consolidation is eligible to run.
+
+Manual consolidation commands may be added later, but the baseline behavior is automatic turn-count-based consolidation.
+
+## 4. Input Scope
+
+The consolidation input is the current thread's model-visible conversation history at the end of a successful turn.
+
+DotCraft intentionally uses the whole thread snapshot rather than only the messages since the last consolidation. This keeps triggering simple and lets the consolidation model compare current conversation history with existing `MEMORY.md` before deciding what changed.
+
+If the visible thread history already contains compacted summary messages, those messages may remain in the consolidation input. They represent part of the conversation state available to the agent and can help the model understand earlier context boundaries.
+
+## 5. Persistence Contract
+
+Consolidation writes two memory layers:
+
+- `MEMORY.md` is updated as a full replacement. The consolidation model reads the current memory and returns the complete updated long-term memory.
+- `HISTORY.md` is append-only. Each consolidation attempt may append one timestamped paragraph describing key events, decisions, and topics.
+
+The operation is best-effort. The system should avoid corrupting existing memory files; if a consolidation attempt cannot produce a valid update, it should leave existing memory unchanged.
+
+Concurrent consolidation attempts should be treated as independent background maintenance work. Implementations should keep each attempted write atomic at the file level and avoid blocking the active turn.
+
+## 6. Failure And Backpressure
+
+Consolidation is fire-and-forget:
+
+- The active turn does not wait for consolidation to complete.
+- A consolidation failure does not fail the turn.
+- A consolidation failure does not trip the compaction circuit breaker.
+- A skipped or failed consolidation attempt is acceptable; the worst expected user-visible outcome is that long-term memory was not updated.
+
+Unlike context compaction, consolidation does not need a circuit breaker in the baseline design. The trigger should remain predictable and simple. If future implementations observe repeated provider failures or excessive load, a separate memory-specific backoff can be added without coupling it to compaction.
+
+## 7. Event Emission
+
+Memory consolidation emits transient `system/event` notifications so clients can display and dismiss maintenance status without blocking the active Turn:
+
+- `consolidating` is emitted through the active turn-scoped event channel after the successful Turn is marked complete and before the background consolidation task is scheduled. It carries the completed Turn's `turnId`.
+- `consolidated` is emitted through the thread event broker after the background task finishes successfully. Because the turn-scoped event channel may already be closed, this event is thread-scoped and carries `turnId = null`.
+- `consolidationFailed` is emitted through the thread event broker if the background task fails. Clients should dismiss any active consolidation status and may surface the event `message`.
+
+These events are status notifications only. They do not create persistent conversation items and do not change the triggering model.
+
+## 8. Configuration
+
+Memory consolidation is controlled by memory-specific configuration:
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| `Memory.AutoConsolidateEnabled` | `true` | Enables automatic turn-count-based consolidation. |
+| `Memory.ConsolidateEveryNTurns` | `5` | Number of successful turns between automatic consolidation attempts per thread. |
+| `ConsolidationModel` | empty | Optional model override for consolidation. Empty means use the main model. |
+
+These settings are independent from `Compaction.*` settings. Disabling context compaction must not disable long-term memory consolidation, and disabling long-term memory consolidation must not change context compaction behavior.
+
+## 9. UX Surface
+
+Desktop exposes memory consolidation as a personalization setting:
+
+- Label: "Enable long-term memory"
+- Meaning: allow DotCraft to progressively accumulate facts about the user and workspace so future sessions can reference them.
+
+Other clients do not need dedicated UI to benefit from the same workspace setting. They may read or update the same workspace configuration through AppServer.
+
+The setting should take effect for future successful turns without requiring an AppServer restart.
+
+## 10. Future Work
+
+Potential extensions:
+
+- Incremental consolidation windows that include only messages since the last successful consolidation.
+- Token-based or idle-time triggers.
+- Manual consolidation commands.
+- Vector or semantic retrieval over consolidated history.
+- User-reviewable memory diffs before writing `MEMORY.md`.
+
+## 11. Data Flow
+
+```mermaid
+flowchart LR
+    subgraph sessionCore [Session Core]
+        turnCompleted[Turn Completed Successfully]
+        counter[Per-Thread Turn Counter]
+        trigger{"Counter reached N"}
+    end
+
+    subgraph memoryFlow [Memory Consolidation]
+        snapshot[Snapshot Thread History]
+        consolidator[MemoryConsolidator]
+        memoryFiles[MEMORY.md and HISTORY.md]
+    end
+
+    turnCompleted --> counter --> trigger
+    trigger -->|yes| snapshot --> consolidator --> memoryFiles
+    trigger -->|no| skip[Skip]
+
+    compactionPipeline[CompactionPipeline] -. independent .-> consolidator
+```

--- a/specs/session-core.md
+++ b/specs/session-core.md
@@ -771,7 +771,7 @@ SessionEvent
     {
       "kind": string,          // One of: "compactWarning", "compactError",
                                 //         "compacting", "compacted", "compactSkipped", "compactFailed",
-                                //         "consolidating", "consolidated"
+                                //         "consolidating", "consolidated", "consolidationFailed"
       "message": string,       // Human-readable description (nullable)
       "percentLeft": double,   // Fraction of the effective context window still unused (nullable; 0.0-1.0)
       "tokenCount": long       // Current estimated prompt token usage (nullable)
@@ -788,16 +788,17 @@ SessionEvent
     | `compacted` | Compaction finished successfully. Token tracker has been reset and `percentLeft`/`tokenCount` reflect the post-compaction state. | Synchronous, immediately after the pipeline returns `Micro` or `Partial`. |
     | `compactSkipped` | Compaction was evaluated but not executed (e.g. below threshold, nothing new to summarize, circuit breaker tripped). | Synchronous, immediately after the pipeline returns `Skipped`. |
     | `compactFailed` | Compaction attempted but failed (LLM error, cancellation). The circuit breaker may trip after several consecutive failures. | Synchronous, immediately after the pipeline returns `Failed`. |
-    | `consolidating` | Memory consolidation is starting. Now driven by the compaction pipeline: the prefix it just summarized is handed to the `MemoryConsolidator`. | Fire-and-forget, immediately after a successful compaction (no post-turn block). |
-    | `consolidated` | Memory consolidation completed successfully. MEMORY.md and HISTORY.md have been updated. | After background consolidation completes. |
+    | `consolidating` | Memory consolidation is starting. Consolidation is driven by Session Core after every configured number of successful Turns, independent from compaction. | Reserved for asynchronous memory-maintenance notifications. |
+    | `consolidated` | Memory consolidation completed successfully. MEMORY.md and HISTORY.md have been updated. | Reserved for asynchronous memory-maintenance notifications. |
+    | `consolidationFailed` | Memory consolidation failed (LLM error, provider error, or persistence failure). UIs should dismiss any active consolidation status. | Asynchronous, after the background consolidation task throws. |
 
   - **Emission rules**:
     - System events are emitted during the Turn's post-processing phase (after agent execution completes, before `turn/completed`), except when raised reactively (see below).
     - The threshold advisory events (`compactWarning`, `compactError`) carry `percentLeft` and `tokenCount` so UIs can render a "context almost full" warning bar without needing a separate usage request.
     - Auto-compaction events (`compacting`, `compacted`, `compactSkipped`, `compactFailed`) are synchronous within Step 5k and always fire in the order `compacting` → one terminal event (`compacted` / `compactSkipped` / `compactFailed`).
     - The pipeline may also be invoked **reactively** from the Turn's error path when the model rejects a request with `prompt_too_long` / `context_length_exceeded`. In that case the Turn still fails, but `compacting` followed by `compacted` / `compactFailed` is emitted first so UIs know the history was repaired before the user retries.
-    - Consolidation events (`consolidating`, `consolidated`) bracket the fire-and-forget background task spawned by the pipeline after a successful compaction. The Turn's completion is **not** deferred for consolidation.
-    - All system events are emitted through the turn-scoped `SessionEventChannel`, so they are guaranteed to arrive before `turn/completed`.
+    - Memory consolidation is a fire-and-forget maintenance task scheduled by Session Core after a configured number of successful Turns. It is not spawned by the compaction pipeline, and Turn completion is **not** deferred for consolidation. Its start event (`consolidating`) is emitted through the turn-scoped `SessionEventChannel`; its terminal events (`consolidated` / `consolidationFailed`) are emitted through the thread event broker with `turnId = null`. See [Memory Consolidation](memory-consolidation.md) for the design contract.
+    - Turn-scoped system events are emitted through the turn-scoped `SessionEventChannel`, so they are guaranteed to arrive before `turn/completed`. Thread-scoped maintenance events may arrive later.
     - The `message` field carries a localized human-readable description suitable for display (on `compactSkipped` / `compactFailed` it contains the machine-readable failure reason, e.g. `circuit_breaker_tripped`, `summary_unavailable`).
   - **Adapters**: Adapters that display session maintenance status (e.g., CLI spinner for consolidation, status text for compaction) should consume `system/event` notifications. Adapters that do not need maintenance status may ignore this event type or opt out via `optOutNotificationMethods`.
 

--- a/src/DotCraft.App/CLI/Rendering/StreamAdapter.cs
+++ b/src/DotCraft.App/CLI/Rendering/StreamAdapter.cs
@@ -286,6 +286,9 @@ public static class StreamAdapter
                 // The completion event dismisses the SystemStatus spinner in the renderer.
                 yield return RenderEvent.SystemInfoEvent(sysEvt.Message ?? Strings.MemoryConsolidated);
                 break;
+            case "consolidationFailed":
+                yield return RenderEvent.SystemInfoEvent(sysEvt.Message ?? Strings.MemoryConsolidationFailed);
+                break;
         }
     }
 }

--- a/src/DotCraft.Core/Agents/AgentFactory.cs
+++ b/src/DotCraft.Core/Agents/AgentFactory.cs
@@ -78,8 +78,7 @@ public sealed class AgentFactory : IAsyncDisposable
 
         CompactionPipeline = new CompactionPipeline(
             config.Compaction,
-            _chatClient.AsIChatClient(),
-            Consolidator);
+            _chatClient.AsIChatClient());
 
         // Build tool provider context
         _toolProviderContext = toolProviderContext ?? new ToolProviderContext
@@ -122,9 +121,8 @@ public sealed class AgentFactory : IAsyncDisposable
 
     /// <summary>
     /// Gets the memory consolidator for persisting conversation knowledge.
-    /// Memory consolidation is driven by the <see cref="CompactionPipeline"/>:
-    /// the prefix that was summarized is handed directly to the consolidator
-    /// so <c>MEMORY.md</c> / <c>HISTORY.md</c> see exactly what the LLM saw.
+    /// Session Core drives consolidation independently from context
+    /// compaction, using completed thread history as input.
     /// </summary>
     public MemoryConsolidator? Consolidator { get; }
 

--- a/src/DotCraft.Core/Configuration/AppConfig.cs
+++ b/src/DotCraft.Core/Configuration/AppConfig.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using DotCraft.Context;
 using DotCraft.Context.Compaction;
 using DotCraft.Localization;
 using DotCraft.Lsp;
@@ -65,6 +66,13 @@ public sealed class AppConfig
     /// </summary>
     [ConfigField(Ignore = true)]
     public CompactionConfig Compaction { get; set; } = new();
+
+    /// <summary>
+    /// Long-term memory consolidation settings. These settings are independent
+    /// from context compaction.
+    /// </summary>
+    [ConfigField(Ignore = true)]
+    public MemoryConfig Memory { get; set; } = new();
 
     /// <summary>
     /// Model used for memory consolidation. When empty, uses <see cref="Model"/> (same as main agent).

--- a/src/DotCraft.Core/Configuration/IAppConfigMonitor.cs
+++ b/src/DotCraft.Core/Configuration/IAppConfigMonitor.cs
@@ -44,6 +44,7 @@ public static class ConfigChangeRegions
     public const string WorkspaceApiKey = "workspace.apiKey";
     public const string WorkspaceEndPoint = "workspace.endpoint";
     public const string WelcomeSuggestions = "welcomeSuggestions";
+    public const string Memory = "memory";
     public const string Skills = "skills";
     public const string WorkspaceDefaultApprovalPolicy = "workspace.defaultApprovalPolicy";
     public const string Mcp = "mcp";

--- a/src/DotCraft.Core/Context/Compaction/CompactionConfig.cs
+++ b/src/DotCraft.Core/Context/Compaction/CompactionConfig.cs
@@ -116,14 +116,6 @@ public sealed class CompactionConfig
     public int MicrocompactGapMinutes { get; set; } = 20;
 
     /// <summary>
-    /// Consolidate MEMORY.md / HISTORY.md when the prefix handed to the
-    /// summary step exceeds this many estimated tokens, even if the pipeline
-    /// did not need to run a full summary.
-    /// </summary>
-    [ConfigField(Min = 0, Hint = "Secondary token-based trigger for memory consolidation.")]
-    public int MemoryConsolidationPrefixTokens { get; set; } = 20_000;
-
-    /// <summary>
     /// Maximum consecutive compaction failures before the pipeline trips its
     /// circuit breaker for this thread and skips future attempts until reset.
     /// </summary>

--- a/src/DotCraft.Core/Context/Compaction/CompactionPipeline.cs
+++ b/src/DotCraft.Core/Context/Compaction/CompactionPipeline.cs
@@ -72,18 +72,15 @@ public sealed class CompactionPipeline
     private readonly CompactionConfig _config;
     private readonly MicroCompactor _micro;
     private readonly PartialCompactor _partial;
-    private readonly MemoryConsolidator? _memoryConsolidator;
     private readonly CompactionFailureTracker _failures;
 
     public CompactionPipeline(
         CompactionConfig config,
-        IChatClient summaryChatClient,
-        MemoryConsolidator? memoryConsolidator = null)
+        IChatClient summaryChatClient)
     {
         _config = config;
         _micro = new MicroCompactor(config);
         _partial = new PartialCompactor(summaryChatClient, config);
-        _memoryConsolidator = memoryConsolidator;
         _failures = new CompactionFailureTracker(config.MaxConsecutiveFailures);
     }
 
@@ -427,11 +424,6 @@ public sealed class CompactionPipeline
         var newHistory = new List<ChatMessage>(1 + partial.PreservedTail.Count) { summaryMessage };
         newHistory.AddRange(partial.PreservedTail);
 
-        if (_memoryConsolidator != null && ShouldConsolidate(partial))
-        {
-            _memoryConsolidator.ConsolidateInBackground(partial.SummarizedPrefix);
-        }
-
         var afterTokens = MessageTokenEstimator.Estimate(newHistory);
         var afterThreshold = EvaluateThreshold(afterTokens);
         _failures.RecordSuccess(threadId);
@@ -445,18 +437,6 @@ public sealed class CompactionPipeline
                 afterThreshold,
                 microResult.ClearedCount),
             newHistory);
-    }
-
-    private bool ShouldConsolidate(PartialCompactResult partial)
-    {
-        if (_memoryConsolidator is null)
-            return false;
-
-        if (_config.MemoryConsolidationPrefixTokens <= 0)
-            return true;
-
-        return partial.PrefixEstimatedTokens >= _config.MemoryConsolidationPrefixTokens
-            || partial.SummarizedPrefix.Count >= 10;
     }
 
     private static IReadOnlyList<ChatMessage> SnapshotHistory(

--- a/src/DotCraft.Core/Context/MemoryConfig.cs
+++ b/src/DotCraft.Core/Context/MemoryConfig.cs
@@ -1,0 +1,22 @@
+using DotCraft.Configuration;
+
+namespace DotCraft.Context;
+
+/// <summary>
+/// Configuration for long-term memory consolidation.
+/// </summary>
+[ConfigSection("Memory", DisplayName = "Memory", Order = 13)]
+public sealed class MemoryConfig
+{
+    /// <summary>
+    /// Enables automatic turn-count-based memory consolidation.
+    /// </summary>
+    [ConfigField(Hint = "Enable automatic long-term memory consolidation after successful turns.", Reload = ReloadBehavior.Hot, HasReload = true)]
+    public bool AutoConsolidateEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Number of successful turns between automatic consolidation attempts per thread.
+    /// </summary>
+    [ConfigField(Min = 1, Hint = "Successful turns between automatic memory consolidation attempts.")]
+    public int ConsolidateEveryNTurns { get; set; } = 5;
+}

--- a/src/DotCraft.Core/Context/MemoryConsolidator.cs
+++ b/src/DotCraft.Core/Context/MemoryConsolidator.cs
@@ -9,9 +9,11 @@ using AiChatRole = Microsoft.Extensions.AI.ChatRole;
 namespace DotCraft.Context;
 
 /// <summary>
-/// Consolidates conversation messages into dual-layer memory:
+/// Consolidates thread history into dual-layer long-term memory:
 /// - MEMORY.md: updated structured long-term facts
 /// - HISTORY.md: appended grep-searchable event paragraph
+/// Session Core schedules consolidation after successful turns; context
+/// compaction does not drive this workflow.
 /// </summary>
 public sealed class MemoryConsolidator(ChatClient chatClient, MemoryStore memoryStore, Action<string>? onStatus = null)
 {
@@ -40,7 +42,7 @@ public sealed class MemoryConsolidator(ChatClient chatClient, MemoryStore memory
         """));
 
     /// <summary>
-    /// Consolidate the given messages into MEMORY.md and HISTORY.md.
+    /// Consolidate the given thread-history snapshot into MEMORY.md and HISTORY.md.
     /// Runs the LLM consolidation call and writes results to disk.
     /// </summary>
     public async Task ConsolidateAsync(
@@ -117,6 +119,7 @@ public sealed class MemoryConsolidator(ChatClient chatClient, MemoryStore memory
         catch (Exception ex)
         {
             onStatus?.Invoke($"[grey][[Memory]][/] [red]Consolidation failed: {Markup.Escape(ex.Message)}[/]");
+            throw;
         }
     }
 

--- a/src/DotCraft.Core/Localization/Languages/en.json
+++ b/src/DotCraft.Core/Localization/Languages/en.json
@@ -97,6 +97,7 @@
 
   "memory.consolidating": "Consolidating memory...",
   "memory.consolidated": "Memory consolidation complete.",
+  "memory.consolidation_failed": "Memory consolidation failed.",
 
   "agent.interrupted": "Agent interrupted",
 

--- a/src/DotCraft.Core/Localization/Languages/zh.json
+++ b/src/DotCraft.Core/Localization/Languages/zh.json
@@ -97,6 +97,7 @@
 
   "memory.consolidating": "正在整理记忆...",
   "memory.consolidated": "记忆整理完成。",
+  "memory.consolidation_failed": "记忆整理失败。",
 
   "agent.interrupted": "Agent 已中断",
 

--- a/src/DotCraft.Core/Localization/Strings.cs
+++ b/src/DotCraft.Core/Localization/Strings.cs
@@ -114,6 +114,7 @@ public static class Strings
     // ── Memory consolidation ─────────────────────────────────────────
     public static string MemoryConsolidating => LanguageService.Current.T("memory.consolidating");
     public static string MemoryConsolidated => LanguageService.Current.T("memory.consolidated");
+    public static string MemoryConsolidationFailed => LanguageService.Current.T("memory.consolidation_failed");
 
     // ── Agent interrupt ──────────────────────────────────────────────
     public static string AgentInterrupted => LanguageService.Current.T("agent.interrupted");

--- a/src/DotCraft.Core/Protocol/AppServer/AppServerProtocol.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/AppServerProtocol.cs
@@ -1740,6 +1740,12 @@ public sealed class WorkspaceConfigUpdateParams
     public bool? SkillsSelfLearningEnabled { get; set; }
 
     /// <summary>
+    /// Workspace-level toggle for long-term memory consolidation. Null removes the workspace override.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    public bool? MemoryAutoConsolidateEnabled { get; set; }
+
+    /// <summary>
     /// Workspace default approval policy. Null removes the workspace override.
     /// Supported values: default, autoApprove.
     /// </summary>
@@ -1786,6 +1792,13 @@ public sealed class WorkspaceConfigUpdateResult
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public bool? SkillsSelfLearningEnabled { get; set; }
+
+    /// <summary>
+    /// Persisted workspace long-term memory consolidation toggle after normalization.
+    /// Null means the workspace override was removed.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    public bool? MemoryAutoConsolidateEnabled { get; set; }
 
     /// <summary>
     /// Persisted workspace default approval policy after normalization.

--- a/src/DotCraft.Core/Protocol/AppServer/AppServerRequestHandler.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/AppServerRequestHandler.cs
@@ -6,6 +6,7 @@ using DotCraft.Abstractions;
 using DotCraft.Commands.Core;
 using DotCraft.Commands.Custom;
 using DotCraft.Configuration;
+using DotCraft.Context;
 using DotCraft.Cron;
 using DotCraft.Heartbeat;
 using DotCraft.Logging;
@@ -1792,6 +1793,20 @@ public sealed class AppServerRequestHandler(
         };
     }
 
+    private void RefreshCurrentMemoryConfig()
+    {
+        if (appConfigMonitor == null || string.IsNullOrWhiteSpace(workspaceCraftPath))
+            return;
+
+        var configPath = Path.Combine(workspaceCraftPath, "config.json");
+        var mergedConfig = AppConfig.LoadWithGlobalFallback(configPath);
+        appConfigMonitor.Current.Memory = new MemoryConfig
+        {
+            AutoConsolidateEnabled = mergedConfig.Memory.AutoConsolidateEnabled,
+            ConsolidateEveryNTurns = mergedConfig.Memory.ConsolidateEveryNTurns
+        };
+    }
+
     private static void SaveWorkspaceExternalChannels(string workspaceCraftPath, IReadOnlyCollection<ExternalChannelEntry> channels)
     {
         var configPath = Path.Combine(workspaceCraftPath, "config.json");
@@ -1852,7 +1867,7 @@ public sealed class AppServerRequestHandler(
         if (string.IsNullOrWhiteSpace(workspaceCraftPath))
             throw AppServerErrors.MethodNotFound(AppServerMethods.WorkspaceConfigUpdate);
         if (!msg.Params.HasValue || msg.Params.Value.ValueKind != JsonValueKind.Object)
-            throw AppServerErrors.InvalidParams("At least one of 'model', 'apiKey', 'endPoint', 'welcomeSuggestionsEnabled', 'skillsSelfLearningEnabled', or 'defaultApprovalPolicy' is required.");
+            throw AppServerErrors.InvalidParams("At least one of 'model', 'apiKey', 'endPoint', 'welcomeSuggestionsEnabled', 'skillsSelfLearningEnabled', 'memoryAutoConsolidateEnabled', or 'defaultApprovalPolicy' is required.");
 
         var hasModel = TryGetCaseInsensitiveProperty(msg.Params.Value, "model", out var modelEl);
         var hasApiKey = TryGetCaseInsensitiveProperty(msg.Params.Value, "apiKey", out var apiKeyEl);
@@ -1865,6 +1880,10 @@ public sealed class AppServerRequestHandler(
             msg.Params.Value,
             "skillsSelfLearningEnabled",
             out var skillsSelfLearningEnabledEl);
+        var hasMemoryAutoConsolidateEnabled = TryGetCaseInsensitiveProperty(
+            msg.Params.Value,
+            "memoryAutoConsolidateEnabled",
+            out var memoryAutoConsolidateEnabledEl);
         var hasDefaultApprovalPolicy = TryGetCaseInsensitiveProperty(
             msg.Params.Value,
             "defaultApprovalPolicy",
@@ -1874,10 +1893,11 @@ public sealed class AppServerRequestHandler(
             && !hasEndPoint
             && !hasWelcomeSuggestionsEnabled
             && !hasSkillsSelfLearningEnabled
+            && !hasMemoryAutoConsolidateEnabled
             && !hasDefaultApprovalPolicy)
         {
             throw AppServerErrors.InvalidParams(
-                "At least one of 'model', 'apiKey', 'endPoint', 'welcomeSuggestionsEnabled', 'skillsSelfLearningEnabled', or 'defaultApprovalPolicy' is required.");
+                "At least one of 'model', 'apiKey', 'endPoint', 'welcomeSuggestionsEnabled', 'skillsSelfLearningEnabled', 'memoryAutoConsolidateEnabled', or 'defaultApprovalPolicy' is required.");
         }
 
         var model = hasModel ? ParseNullableString(modelEl, "model") : null;
@@ -1888,6 +1908,9 @@ public sealed class AppServerRequestHandler(
             : null;
         var skillsSelfLearningEnabled = hasSkillsSelfLearningEnabled
             ? ParseNullableBoolean(skillsSelfLearningEnabledEl, "skillsSelfLearningEnabled")
+            : null;
+        var memoryAutoConsolidateEnabled = hasMemoryAutoConsolidateEnabled
+            ? ParseNullableBoolean(memoryAutoConsolidateEnabledEl, "memoryAutoConsolidateEnabled")
             : null;
         var defaultApprovalPolicy = hasDefaultApprovalPolicy
             ? ParseNullableString(defaultApprovalPolicyEl, "defaultApprovalPolicy")
@@ -1900,12 +1923,14 @@ public sealed class AppServerRequestHandler(
             hasEndPoint ? NormalizeOptionalString(endPoint) : null,
             welcomeSuggestionsEnabled,
             skillsSelfLearningEnabled,
+            memoryAutoConsolidateEnabled,
             hasDefaultApprovalPolicy ? NormalizeDefaultApprovalPolicy(defaultApprovalPolicy) : null,
             hasModel,
             hasApiKey,
             hasEndPoint,
             hasWelcomeSuggestionsEnabled,
             hasSkillsSelfLearningEnabled,
+            hasMemoryAutoConsolidateEnabled,
             hasDefaultApprovalPolicy);
 
         var changedRegions = new List<string>();
@@ -1919,6 +1944,11 @@ public sealed class AppServerRequestHandler(
             changedRegions.Add(ConfigChangeRegions.WelcomeSuggestions);
         if (saveResult.SkillsSelfLearningChanged)
             changedRegions.Add(ConfigChangeRegions.Skills);
+        if (saveResult.MemoryAutoConsolidateChanged)
+        {
+            changedRegions.Add(ConfigChangeRegions.Memory);
+            RefreshCurrentMemoryConfig();
+        }
         if (saveResult.DefaultApprovalPolicyChanged)
         {
             changedRegions.Add(ConfigChangeRegions.WorkspaceDefaultApprovalPolicy);
@@ -1938,6 +1968,7 @@ public sealed class AppServerRequestHandler(
             EndPoint = saveResult.EndPoint,
             WelcomeSuggestionsEnabled = saveResult.WelcomeSuggestionsEnabled,
             SkillsSelfLearningEnabled = saveResult.SkillsSelfLearningEnabled,
+            MemoryAutoConsolidateEnabled = saveResult.MemoryAutoConsolidateEnabled,
             DefaultApprovalPolicy = saveResult.DefaultApprovalPolicy
         });
     }
@@ -2609,12 +2640,14 @@ public sealed class AppServerRequestHandler(
         string? endPoint,
         bool? welcomeSuggestionsEnabled,
         bool? skillsSelfLearningEnabled,
+        bool? memoryAutoConsolidateEnabled,
         string? defaultApprovalPolicy,
         bool updateModel,
         bool updateApiKey,
         bool updateEndPoint,
         bool updateWelcomeSuggestionsEnabled,
         bool updateSkillsSelfLearningEnabled,
+        bool updateMemoryAutoConsolidateEnabled,
         bool updateDefaultApprovalPolicy)
     {
         var configPath = Path.Combine(workspaceCraftPath, "config.json");
@@ -2631,6 +2664,8 @@ public sealed class AppServerRequestHandler(
             ? null
             : GetOrCreateConfigSection(skillsSection, "SelfLearning", createIfMissing: updateSkillsSelfLearningEnabled);
         var selfLearningEnabledKey = selfLearningSection == null ? null : FindCaseInsensitiveKey(selfLearningSection, "Enabled");
+        var memorySection = GetOrCreateConfigSection(root, "Memory", createIfMissing: updateMemoryAutoConsolidateEnabled);
+        var memoryAutoConsolidateEnabledKey = memorySection == null ? null : FindCaseInsensitiveKey(memorySection, "AutoConsolidateEnabled");
         var permissionsSection = GetOrCreateConfigSection(root, "Permissions", createIfMissing: updateDefaultApprovalPolicy);
         var defaultApprovalPolicyKey = permissionsSection == null ? null : FindCaseInsensitiveKey(permissionsSection, "DefaultApprovalPolicy");
 
@@ -2639,6 +2674,7 @@ public sealed class AppServerRequestHandler(
         var existingEndPoint = NormalizeOptionalString(ReadConfigStringValue(root, endPointKey));
         var existingWelcomeSuggestionsEnabled = ReadConfigBooleanValue(welcomeSection, welcomeEnabledKey);
         var existingSkillsSelfLearningEnabled = ReadConfigBooleanValue(selfLearningSection, selfLearningEnabledKey);
+        var existingMemoryAutoConsolidateEnabled = ReadConfigBooleanValue(memorySection, memoryAutoConsolidateEnabledKey);
         var existingDefaultApprovalPolicy = NormalizeDefaultApprovalPolicy(ReadConfigStringValue(permissionsSection, defaultApprovalPolicyKey));
 
         var modelChanged = updateModel && !string.Equals(existingModel, model, StringComparison.Ordinal);
@@ -2648,6 +2684,8 @@ public sealed class AppServerRequestHandler(
             && existingWelcomeSuggestionsEnabled != welcomeSuggestionsEnabled;
         var skillsSelfLearningChanged = updateSkillsSelfLearningEnabled
             && existingSkillsSelfLearningEnabled != skillsSelfLearningEnabled;
+        var memoryAutoConsolidateChanged = updateMemoryAutoConsolidateEnabled
+            && existingMemoryAutoConsolidateEnabled != memoryAutoConsolidateEnabled;
         var defaultApprovalPolicyChanged = updateDefaultApprovalPolicy
             && !string.Equals(existingDefaultApprovalPolicy, defaultApprovalPolicy, StringComparison.Ordinal);
 
@@ -2673,6 +2711,13 @@ public sealed class AppServerRequestHandler(
             RemoveConfigSectionIfEmpty(skills, "SelfLearning");
             RemoveConfigSectionIfEmpty(root, "Skills");
         }
+        if (updateMemoryAutoConsolidateEnabled)
+        {
+            var memory = GetOrCreateConfigSection(root, "Memory", createIfMissing: true)!;
+            var autoConsolidateExistingKey = FindCaseInsensitiveKey(memory, "AutoConsolidateEnabled");
+            UpsertOrRemoveConfigValue(memory, autoConsolidateExistingKey, "AutoConsolidateEnabled", memoryAutoConsolidateEnabled);
+            RemoveConfigSectionIfEmpty(root, "Memory");
+        }
         if (updateDefaultApprovalPolicy)
         {
             var permissions = GetOrCreateConfigSection(root, "Permissions", createIfMissing: true)!;
@@ -2686,6 +2731,7 @@ public sealed class AppServerRequestHandler(
             || endPointChanged
             || welcomeSuggestionsChanged
             || skillsSelfLearningChanged
+            || memoryAutoConsolidateChanged
             || defaultApprovalPolicyChanged)
         {
             var json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
@@ -2703,6 +2749,9 @@ public sealed class AppServerRequestHandler(
             SkillsSelfLearningEnabled = updateSkillsSelfLearningEnabled
                 ? skillsSelfLearningEnabled
                 : existingSkillsSelfLearningEnabled,
+            MemoryAutoConsolidateEnabled = updateMemoryAutoConsolidateEnabled
+                ? memoryAutoConsolidateEnabled
+                : existingMemoryAutoConsolidateEnabled,
             DefaultApprovalPolicy = updateDefaultApprovalPolicy
                 ? defaultApprovalPolicy
                 : existingDefaultApprovalPolicy,
@@ -2711,6 +2760,7 @@ public sealed class AppServerRequestHandler(
             EndPointChanged = endPointChanged,
             WelcomeSuggestionsChanged = welcomeSuggestionsChanged,
             SkillsSelfLearningChanged = skillsSelfLearningChanged,
+            MemoryAutoConsolidateChanged = memoryAutoConsolidateChanged,
             DefaultApprovalPolicyChanged = defaultApprovalPolicyChanged
         };
     }
@@ -2862,6 +2912,8 @@ public sealed class AppServerRequestHandler(
 
         public bool? SkillsSelfLearningEnabled { get; init; }
 
+        public bool? MemoryAutoConsolidateEnabled { get; init; }
+
         public string? DefaultApprovalPolicy { get; init; }
 
         public bool ModelChanged { get; init; }
@@ -2873,6 +2925,8 @@ public sealed class AppServerRequestHandler(
         public bool WelcomeSuggestionsChanged { get; init; }
 
         public bool SkillsSelfLearningChanged { get; init; }
+
+        public bool MemoryAutoConsolidateChanged { get; init; }
 
         public bool DefaultApprovalPolicyChanged { get; init; }
     }

--- a/src/DotCraft.Core/Protocol/SessionEvent.cs
+++ b/src/DotCraft.Core/Protocol/SessionEvent.cs
@@ -21,7 +21,8 @@ public sealed class SessionEvent
     public string ThreadId { get; set; } = string.Empty;
 
     /// <summary>
-    /// Parent Turn ID. Null for thread-level events (thread/created, thread/resumed, thread/statusChanged).
+    /// Parent Turn ID. Null for thread-level events (thread/created, thread/resumed, thread/statusChanged)
+    /// and thread-scoped maintenance events.
     /// </summary>
     public string? TurnId { get; set; }
 
@@ -241,7 +242,7 @@ public sealed record SystemEventPayload
     /// <summary>
     /// System event kind. One of: "compactWarning", "compactError",
     /// "compacting", "compacted", "compactSkipped", "compactFailed",
-    /// "consolidating", "consolidated".
+    /// "consolidating", "consolidated", "consolidationFailed".
     /// </summary>
     public required string Kind { get; init; }
 

--- a/src/DotCraft.Core/Protocol/SessionEventHandler.cs
+++ b/src/DotCraft.Core/Protocol/SessionEventHandler.cs
@@ -76,7 +76,7 @@ public sealed class SessionEventHandler
 
     /// <summary>
     /// Called when a system-level maintenance event arrives (<see cref="SessionEventType.SystemEvent"/>).
-    /// The payload carries the event kind (compacting, compacted, consolidating, etc.) and an optional message.
+    /// The payload carries the event kind (compacting, compacted, consolidating, consolidationFailed, etc.) and an optional message.
     /// Optional; if null, system events are silently dropped.
     /// </summary>
     public Func<SystemEventPayload, Task>? OnSystemEvent { get; init; }

--- a/src/DotCraft.Core/Protocol/SessionService.cs
+++ b/src/DotCraft.Core/Protocol/SessionService.cs
@@ -64,6 +64,7 @@ public sealed class SessionService(
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _threadQueueLocks = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _threadAgentLocks = new();
     private readonly ConcurrentDictionary<string, byte> _materializedThreads = new();
+    private readonly ConcurrentDictionary<string, int> _turnsSinceConsolidation = new();
     private readonly ConcurrentDictionary<string, byte> _threadsPendingPermanentDeletion = new();
     private readonly ConcurrentDictionary<string, IReadOnlySet<string>> _threadExternalChannelToolNames = new();
     private static readonly IReadOnlySet<string> EmptyExternalToolNames = new HashSet<string>(StringComparer.Ordinal);
@@ -327,6 +328,7 @@ public sealed class SessionService(
             if (_threadAgentLocks.TryRemove(normalizedThreadId, out var agentLock))
                 agentLock.Dispose();
             _materializedThreads.TryRemove(normalizedThreadId, out _);
+            _turnsSinceConsolidation.TryRemove(normalizedThreadId, out _);
             _threadExternalChannelToolNames.TryRemove(normalizedThreadId, out _);
             if (_threadMcpManagers.TryRemove(normalizedThreadId, out var mcpManager))
                 await mcpManager.DisposeAsync();
@@ -1381,6 +1383,7 @@ public sealed class SessionService(
                 thread.LastActiveAt = DateTimeOffset.UtcNow;
                 RecordTurnTokenUsage(thread, turn);
                 eventChannel.EmitTurnCompleted(turn);
+                TryScheduleMemoryConsolidation(threadId, session, eventChannel);
                 ThreadRuntimeSignalForBroadcast?.Invoke(
                     threadId,
                     EndsWithSuccessfulCreatePlanInPlanMode(thread, turn)
@@ -2196,6 +2199,58 @@ public sealed class SessionService(
         }
 
         return false;
+    }
+
+    private void TryScheduleMemoryConsolidation(
+        string threadId,
+        AgentSession session,
+        SessionEventChannel eventChannel)
+    {
+        var consolidator = agentFactory.Consolidator;
+        var memoryConfig = _appConfigMonitor?.Current.Memory
+            ?? agentFactory.ToolProviderContext.Config.Memory;
+
+        if (consolidator is null || !memoryConfig.AutoConsolidateEnabled)
+            return;
+
+        var interval = Math.Max(1, memoryConfig.ConsolidateEveryNTurns);
+        var count = _turnsSinceConsolidation.AddOrUpdate(
+            threadId,
+            1,
+            static (_, previous) => previous + 1);
+
+        if (count < interval)
+            return;
+
+        _turnsSinceConsolidation[threadId] = 0;
+        var history = SnapshotSessionHistoryForConsolidation(session);
+        if (history.Count == 0)
+            return;
+
+        eventChannel.EmitSystemEvent("consolidating");
+
+        var broker = GetOrCreateBroker(threadId);
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await consolidator.ConsolidateAsync(history);
+                broker.PublishSystemEvent("consolidated");
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Memory consolidation failed for thread {ThreadId}", threadId);
+                broker.PublishSystemEvent("consolidationFailed", message: ex.Message);
+            }
+        });
+    }
+
+    private static IReadOnlyList<ChatMessage> SnapshotSessionHistoryForConsolidation(AgentSession session)
+    {
+        var chatHistory = session.GetService<ChatHistoryProvider>();
+        return chatHistory is InMemoryChatHistoryProvider provider
+            ? [.. provider.GetMessages(session)]
+            : [];
     }
 
     private async Task TrySaveThreadAsync(SessionThread thread)

--- a/src/DotCraft.Core/Protocol/ThreadEventBroker.cs
+++ b/src/DotCraft.Core/Protocol/ThreadEventBroker.cs
@@ -67,6 +67,26 @@ internal sealed class ThreadEventBroker(string threadId)
             });
     }
 
+    /// <summary>
+    /// Publishes a thread-scoped system maintenance event.
+    /// </summary>
+    public void PublishSystemEvent(
+        string kind,
+        string? message = null,
+        double? percentLeft = null,
+        long? tokenCount = null)
+    {
+        PublishThreadEvent(
+            SessionEventType.SystemEvent,
+            new SystemEventPayload
+            {
+                Kind = kind,
+                Message = message,
+                PercentLeft = percentLeft,
+                TokenCount = tokenCount
+            });
+    }
+
     public void PublishItemEvent(SessionEventType eventType, string turnId, SessionItem item)
     {
         var payload = new SessionItem

--- a/src/DotCraft.Core/Tools/FileTools.cs
+++ b/src/DotCraft.Core/Tools/FileTools.cs
@@ -10,6 +10,10 @@ namespace DotCraft.Tools;
 /// <summary>
 /// File system tools: read, write, edit, search files with safety guards.
 /// </summary>
+/// <remarks>
+/// Write and edit operations serialize per canonical file path across the process so concurrent
+/// tool calls cannot overlap their read-modify-write sections.
+/// </remarks>
 public sealed class FileTools(
     string workspaceRoot,
     bool requireApprovalOutsideWorkspace = true,
@@ -104,7 +108,7 @@ public sealed class FileTools(
                         "Error: Line offset/limit pagination is not supported for image files; call ReadFile without offset and limit to load the image as vision input.");
                 }
 
-                var bytes = await File.ReadAllBytesAsync(fullPath);
+                var bytes = await WithSharingViolationRetryAsync(() => File.ReadAllBytesAsync(fullPath));
                 var summary = $"Image: {path} ({bytes.Length:N0} bytes, {mediaType})";
                 return [new TextContent(summary), new DataContent(bytes, mediaType)];
             }
@@ -113,7 +117,7 @@ public sealed class FileTools(
 
             if (offset > 0)
             {
-                var lines = await File.ReadAllLinesAsync(fullPath, encoding);
+                var lines = await WithSharingViolationRetryAsync(() => File.ReadAllLinesAsync(fullPath, encoding));
                 var startIndex = offset - 1;
                 if (startIndex >= lines.Length)
                     return ReadFileTextResult($"Error: Offset {offset} is out of range for this file ({lines.Length} lines).");
@@ -137,7 +141,7 @@ public sealed class FileTools(
                 return ReadFileTextResult(sb.ToString());
             }
 
-            return ReadFileTextResult(await File.ReadAllTextAsync(fullPath, encoding));
+            return ReadFileTextResult(await WithSharingViolationRetryAsync(() => File.ReadAllTextAsync(fullPath, encoding)));
         }
         catch (UnauthorizedAccessException)
         {
@@ -174,17 +178,22 @@ public sealed class FileTools(
             if (!string.IsNullOrEmpty(directory))
                 Directory.CreateDirectory(directory);
 
-            var encoding = File.Exists(fullPath) ? DetectFileEncoding(fullPath) : Utf8NoBom;
-            if (File.Exists(fullPath))
+            using (await PathAsyncMutex.AcquireAsync(fullPath))
             {
-                var existing = await File.ReadAllTextAsync(fullPath, encoding);
-                content = RestoreLineEndings(NormalizeToLf(content), UsesCrLf(existing));
+                var encoding = File.Exists(fullPath) ? DetectFileEncoding(fullPath) : Utf8NoBom;
+                if (File.Exists(fullPath))
+                {
+                    var existing = await File.ReadAllTextAsync(fullPath, encoding);
+                    content = RestoreLineEndings(NormalizeToLf(content), UsesCrLf(existing));
+                }
+                else
+                {
+                    content = NormalizeToLf(content);
+                }
+
+                await File.WriteAllTextAsync(fullPath, content, encoding);
             }
-            else
-            {
-                content = NormalizeToLf(content);
-            }
-            await File.WriteAllTextAsync(fullPath, content, encoding);
+
             await NotifyLspFileChangedAsync(fullPath, content);
             var lineCount = content.Split('\n').Length;
             return $"Successfully wrote {content.Length} bytes ({lineCount} lines) to {path}";
@@ -214,23 +223,27 @@ public sealed class FileTools(
             if (validateResult != null)
                 return validateResult;
 
-            if (!File.Exists(fullPath))
-                return $"Error: File not found: {path}";
-
-            var encoding = DetectFileEncoding(fullPath);
-            var content = await File.ReadAllTextAsync(fullPath, encoding);
             newText = UnescapeUnicodeSequences(newText);
 
             if (string.IsNullOrEmpty(oldText))
                 return "Error: oldText is required. Provide the exact snippet to find and replace.";
 
             oldText = UnescapeUnicodeSequences(oldText);
-            var result = await ApplySearchReplaceEdit(fullPath, path, content, oldText, newText, encoding, replaceAll);
-            if (result.StartsWith("Successfully", StringComparison.Ordinal))
+
+            string result;
+            string? writtenContent;
+            using (await PathAsyncMutex.AcquireAsync(fullPath))
             {
-                var latest = await File.ReadAllTextAsync(fullPath, encoding);
-                await NotifyLspFileChangedAsync(fullPath, latest);
+                if (!File.Exists(fullPath))
+                    return $"Error: File not found: {path}";
+
+                var encoding = DetectFileEncoding(fullPath);
+                var content = await File.ReadAllTextAsync(fullPath, encoding);
+                (result, writtenContent) = await ApplySearchReplaceEdit(fullPath, path, content, oldText, newText, encoding, replaceAll);
             }
+
+            if (writtenContent != null)
+                await NotifyLspFileChangedAsync(fullPath, writtenContent);
 
             return result;
         }
@@ -542,7 +555,7 @@ public sealed class FileTools(
         }
     }
 
-    private static async Task<string> ApplySearchReplaceEdit(
+    private static async Task<(string Result, string? WrittenContent)> ApplySearchReplaceEdit(
         string fullPath, string displayPath, string content, string oldText, string newText,
         Encoding encoding, bool replaceAll)
     {
@@ -555,18 +568,37 @@ public sealed class FileTools(
         var (ok, newLfContent, error, matchKind, lineNum, oldLineCount, replaceCount) =
             FileEditSearchReplace.Apply(content, oldText, newText, replaceAll);
         if (!ok)
-            return error!;
+            return (error!, null);
 
         var newContent = RestoreLineEndings(newLfContent, useCrLf);
         await File.WriteAllTextAsync(fullPath, newContent, encoding);
 
         if (replaceCount > 1)
-            return $"Successfully replaced {replaceCount} occurrences in {displayPath}";
+            return ($"Successfully replaced {replaceCount} occurrences in {displayPath}", newContent);
 
         var newLineCount = string.IsNullOrEmpty(newText) ? 0 : newText.Count(c => c == '\n') + 1;
         var suffix = matchKind != null ? $" ({matchKind})" : "";
-        return $"Successfully edited {displayPath} at line {lineNum} ({oldLineCount} -> {newLineCount} lines){suffix}";
+        return ($"Successfully edited {displayPath} at line {lineNum} ({oldLineCount} -> {newLineCount} lines){suffix}", newContent);
     }
+
+    private static async Task<T> WithSharingViolationRetryAsync<T>(Func<Task<T>> operation)
+    {
+        var delays = new[] { 20, 40, 80 };
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                return await operation();
+            }
+            catch (IOException ex) when (attempt < delays.Length && IsSharingOrLockViolation(ex))
+            {
+                await Task.Delay(delays[attempt]);
+            }
+        }
+    }
+
+    private static bool IsSharingOrLockViolation(IOException ex)
+        => ex.HResult is unchecked((int)0x80070020) or unchecked((int)0x80070021);
 
     private static bool UsesCrLf(string content)
         => content.Contains("\r\n");

--- a/src/DotCraft.Core/Tools/PathAsyncMutex.cs
+++ b/src/DotCraft.Core/Tools/PathAsyncMutex.cs
@@ -1,0 +1,81 @@
+namespace DotCraft.Tools;
+
+/// <summary>
+/// Process-wide async mutex keyed by canonical file path.
+/// </summary>
+internal static class PathAsyncMutex
+{
+    private static readonly object Gate = new();
+    private static readonly Dictionary<string, Entry> Entries = new(StringComparer.Ordinal);
+
+    internal static async Task<IDisposable> AcquireAsync(string fullPath, CancellationToken cancellationToken = default)
+        => await AcquireKeyAsync(Canonicalize(fullPath), cancellationToken);
+
+    internal static async Task<IDisposable> AcquireKeyAsync(string key, CancellationToken cancellationToken = default)
+    {
+        Entry entry;
+        lock (Gate)
+        {
+            if (!Entries.TryGetValue(key, out entry!))
+            {
+                entry = new Entry();
+                Entries[key] = entry;
+            }
+
+            entry.RefCount++;
+        }
+
+        try
+        {
+            await entry.Semaphore.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            ReleaseReference(key, entry);
+            throw;
+        }
+
+        return new Releaser(key, entry);
+    }
+
+    private static string Canonicalize(string fullPath)
+    {
+        var path = Path.GetFullPath(fullPath);
+        return OperatingSystem.IsWindows()
+            ? path.ToLowerInvariant()
+            : path;
+    }
+
+    private static void ReleaseReference(string key, Entry entry)
+    {
+        lock (Gate)
+        {
+            entry.RefCount--;
+            if (entry.RefCount == 0)
+            {
+                Entries.Remove(key);
+                entry.Semaphore.Dispose();
+            }
+        }
+    }
+
+    private sealed class Entry
+    {
+        internal readonly SemaphoreSlim Semaphore = new(1, 1);
+        internal int RefCount;
+    }
+
+    private sealed class Releaser(string key, Entry entry) : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            entry.Semaphore.Release();
+            ReleaseReference(key, entry);
+        }
+    }
+}

--- a/src/DotCraft.Core/Tools/Sandbox/SandboxFileTools.cs
+++ b/src/DotCraft.Core/Tools/Sandbox/SandboxFileTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
+using DotCraft.Tools;
 using OpenSandbox.Models;
 
 namespace DotCraft.Tools.Sandbox;
@@ -105,18 +106,21 @@ public sealed class SandboxFileTools
             var sandbox = await _sandboxManager.GetOrCreateAsync();
             var fullPath = ResolveSandboxPath(path);
 
-            // Ensure parent directory exists
-            var parentDir = fullPath[..fullPath.LastIndexOf('/')];
-            if (!string.IsNullOrEmpty(parentDir))
+            using (await PathAsyncMutex.AcquireKeyAsync($"sandbox:{fullPath}"))
             {
-                await sandbox.Files.CreateDirectoriesAsync([
-                    new CreateDirectoryEntry { Path = parentDir, Mode = 755 }
+                // Ensure parent directory exists
+                var parentDir = fullPath[..fullPath.LastIndexOf('/')];
+                if (!string.IsNullOrEmpty(parentDir))
+                {
+                    await sandbox.Files.CreateDirectoriesAsync([
+                        new CreateDirectoryEntry { Path = parentDir, Mode = 755 }
+                    ]);
+                }
+
+                await sandbox.Files.WriteFilesAsync([
+                    new WriteEntry { Path = fullPath, Data = content, Mode = 644 }
                 ]);
             }
-
-            await sandbox.Files.WriteFilesAsync([
-                new WriteEntry { Path = fullPath, Data = content, Mode = 644 }
-            ]);
 
             var lineCount = content.Split('\n').Length;
             return $"Successfully wrote {content.Length} bytes ({lineCount} lines) to {path}";
@@ -147,32 +151,40 @@ public sealed class SandboxFileTools
             var sandbox = await _sandboxManager.GetOrCreateAsync();
             var fullPath = ResolveSandboxPath(path);
 
-            var content = await sandbox.Files.ReadFileAsync(fullPath);
             newText = UnescapeUnicodeSequences(newText);
             oldText = UnescapeUnicodeSequences(oldText);
 
-            var useCrLf = content.Contains("\r\n", StringComparison.Ordinal);
-            var lfContent = content.Replace("\r\n", "\n", StringComparison.Ordinal);
-            var lfOld = oldText.Replace("\r\n", "\n", StringComparison.Ordinal);
-            var lfNew = newText.Replace("\r\n", "\n", StringComparison.Ordinal);
+            string result;
+            using (await PathAsyncMutex.AcquireKeyAsync($"sandbox:{fullPath}"))
+            {
+                var content = await sandbox.Files.ReadFileAsync(fullPath);
+                var useCrLf = content.Contains("\r\n", StringComparison.Ordinal);
+                var lfContent = content.Replace("\r\n", "\n", StringComparison.Ordinal);
+                var lfOld = oldText.Replace("\r\n", "\n", StringComparison.Ordinal);
+                var lfNew = newText.Replace("\r\n", "\n", StringComparison.Ordinal);
 
-            var (ok, newLfContent, error, matchKind, lineNum, oldLineCount, replaceCount) =
-                FileEditSearchReplace.Apply(lfContent, lfOld, lfNew, replaceAll);
-            if (!ok)
-                return error!;
+                var (ok, newLfContent, error, matchKind, lineNum, oldLineCount, replaceCount) =
+                    FileEditSearchReplace.Apply(lfContent, lfOld, lfNew, replaceAll);
+                if (!ok)
+                    return error!;
 
-            var newContent = useCrLf ? newLfContent.Replace("\n", "\r\n", StringComparison.Ordinal) : newLfContent;
+                var newContent = useCrLf ? newLfContent.Replace("\n", "\r\n", StringComparison.Ordinal) : newLfContent;
 
-            await sandbox.Files.WriteFilesAsync([
-                new WriteEntry { Path = fullPath, Data = newContent, Mode = 644 }
-            ]);
+                await sandbox.Files.WriteFilesAsync([
+                    new WriteEntry { Path = fullPath, Data = newContent, Mode = 644 }
+                ]);
 
-            if (replaceCount > 1)
-                return $"Successfully replaced {replaceCount} occurrences in {path}";
+                if (replaceCount > 1)
+                    result = $"Successfully replaced {replaceCount} occurrences in {path}";
+                else
+                {
+                    var newLineCount = string.IsNullOrEmpty(lfNew) ? 0 : lfNew.Count(c => c == '\n') + 1;
+                    var suffix = matchKind != null ? $" ({matchKind})" : "";
+                    result = $"Successfully edited {path} at line {lineNum} ({oldLineCount} -> {newLineCount} lines){suffix}";
+                }
+            }
 
-            var newLineCount = string.IsNullOrEmpty(lfNew) ? 0 : lfNew.Count(c => c == '\n') + 1;
-            var suffix = matchKind != null ? $" ({matchKind})" : "";
-            return $"Successfully edited {path} at line {lineNum} ({oldLineCount} -> {newLineCount} lines){suffix}";
+            return result;
         }
         catch (OpenSandbox.Core.SandboxException ex)
         {

--- a/tests/DotCraft.Core.Tests/Protocol/AppServer/WorkspaceConfigChangedTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/AppServer/WorkspaceConfigChangedTests.cs
@@ -1,4 +1,5 @@
 using DotCraft.Configuration;
+using DotCraft.Context;
 using DotCraft.Mcp;
 using DotCraft.Protocol;
 using DotCraft.Protocol.AppServer;
@@ -161,6 +162,83 @@ public sealed class WorkspaceConfigChangedTests : IDisposable
     }
 
     [Fact]
+    public async Task WorkspaceConfigUpdate_MemoryAutoConsolidateOnly_WritesConfigUpdatesMonitorAndEmitsMemoryRegion()
+    {
+        var configPath = Path.Combine(_workspaceCraftPath, "config.json");
+        using var harness = new AppServerTestHarness(workspaceCraftPath: _workspaceCraftPath);
+        using var bridge = AttachConfigChangedBridge(harness);
+        await harness.InitializeAsync(configChange: true);
+
+        var req = harness.BuildRequest(AppServerMethods.WorkspaceConfigUpdate, new
+        {
+            memoryAutoConsolidateEnabled = false
+        });
+        await harness.ExecuteRequestAsync(req);
+
+        var sent = await harness.Transport.WaitAndDrainAsync(2, TimeSpan.FromSeconds(5));
+        AssertSingleConfigChanged(sent, AppServerMethods.WorkspaceConfigUpdate, ConfigChangeRegions.Memory);
+        var json = await File.ReadAllTextAsync(configPath);
+        using var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.GetProperty("Memory").GetProperty("AutoConsolidateEnabled").GetBoolean());
+        Assert.False(harness.Monitor.Current.Memory.AutoConsolidateEnabled);
+    }
+
+    [Fact]
+    public async Task WorkspaceConfigUpdate_MemoryAutoConsolidateNull_RemovesLeafAndPrunesEmptySection()
+    {
+        var configPath = Path.Combine(_workspaceCraftPath, "config.json");
+        await File.WriteAllTextAsync(
+            configPath,
+            """
+            {
+              "Memory": {
+                "AutoConsolidateEnabled": false
+              }
+            }
+            """);
+
+        var monitor = new AppConfigMonitor(new AppConfig
+        {
+            Memory = new MemoryConfig
+            {
+                AutoConsolidateEnabled = false
+            }
+        });
+        using var harness = new AppServerTestHarness(workspaceCraftPath: _workspaceCraftPath, appConfigMonitor: monitor);
+        using var bridge = AttachConfigChangedBridge(harness);
+        await harness.InitializeAsync(configChange: true);
+
+        using var requestDoc = JsonDocument.Parse(
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "method": "workspace/config/update",
+              "params": {
+                "memoryAutoConsolidateEnabled": null
+              }
+            }
+            """);
+        var req = new AppServerIncomingMessage
+        {
+            JsonRpc = "2.0",
+            Id = requestDoc.RootElement.GetProperty("id").Clone(),
+            Method = AppServerMethods.WorkspaceConfigUpdate,
+            Params = requestDoc.RootElement.GetProperty("params").Clone()
+        };
+        await harness.ExecuteRequestAsync(req);
+
+        var sent = await harness.Transport.WaitAndDrainAsync(2, TimeSpan.FromSeconds(5));
+        var response = Assert.Single(sent, d => d.RootElement.TryGetProperty("result", out _));
+        Assert.Equal(JsonValueKind.Null, response.RootElement.GetProperty("result").GetProperty("memoryAutoConsolidateEnabled").ValueKind);
+        AssertSingleConfigChanged(sent, AppServerMethods.WorkspaceConfigUpdate, ConfigChangeRegions.Memory);
+        var json = await File.ReadAllTextAsync(configPath);
+        using var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.TryGetProperty("Memory", out _));
+        Assert.True(harness.Monitor.Current.Memory.AutoConsolidateEnabled);
+    }
+
+    [Fact]
     public async Task WorkspaceConfigUpdate_DefaultApprovalPolicy_RoundTripsAndEmitsRegion()
     {
         var configPath = Path.Combine(_workspaceCraftPath, "config.json");
@@ -257,6 +335,7 @@ public sealed class WorkspaceConfigChangedTests : IDisposable
             endPoint = "https://example.com/v1",
             welcomeSuggestionsEnabled = false,
             skillsSelfLearningEnabled = true,
+            memoryAutoConsolidateEnabled = false,
             defaultApprovalPolicy = "autoApprove"
         });
         await harness.ExecuteRequestAsync(req);
@@ -271,6 +350,7 @@ public sealed class WorkspaceConfigChangedTests : IDisposable
                 ConfigChangeRegions.WorkspaceEndPoint,
                 ConfigChangeRegions.WelcomeSuggestions,
                 ConfigChangeRegions.Skills,
+                ConfigChangeRegions.Memory,
                 ConfigChangeRegions.WorkspaceDefaultApprovalPolicy
             ]);
     }

--- a/tests/DotCraft.Core.Tests/Protocol/SessionEventChannelTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/SessionEventChannelTests.cs
@@ -216,6 +216,23 @@ public sealed class SessionEventChannelTests
         Assert.Equal(ThreadStatus.Paused, payload.NewStatus);
     }
 
+    [Fact]
+    public async Task EmitSystemEvent_ContainsSystemPayload()
+    {
+        var channel = MakeChannel();
+
+        channel.EmitSystemEvent("consolidationFailed", message: "provider unavailable");
+        channel.Complete();
+
+        var events = await CollectAsync(channel);
+        var payload = events[0].SystemEventPayload;
+        Assert.NotNull(payload);
+        Assert.Equal(SessionEventType.SystemEvent, events[0].EventType);
+        Assert.Equal(TestTurnId, events[0].TurnId);
+        Assert.Equal("consolidationFailed", payload.Kind);
+        Assert.Equal("provider unavailable", payload.Message);
+    }
+
     // -------------------------------------------------------------------------
     // Snapshot semantics (spec appserver-protocol.md §6.3)
     // -------------------------------------------------------------------------

--- a/tests/DotCraft.Core.Tests/Protocol/ThreadEventBrokerTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/ThreadEventBrokerTests.cs
@@ -54,6 +54,26 @@ public sealed class ThreadEventBrokerTests
         Assert.Null(events[0].TurnId);
     }
 
+    [Fact]
+    public async Task PublishSystemEvent_PublishesThreadScopedSystemPayload()
+    {
+        var broker = new ThreadEventBroker("thread_001");
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var collectTask = CollectAsync(broker.SubscribeAsync(ct: cts.Token), expectedCount: 1, cts);
+
+        broker.PublishSystemEvent("consolidationFailed", message: "provider unavailable");
+
+        var events = await collectTask;
+        Assert.Single(events);
+        var payload = events[0].SystemEventPayload;
+        Assert.NotNull(payload);
+        Assert.Equal(SessionEventType.SystemEvent, events[0].EventType);
+        Assert.Equal("thread_001", events[0].ThreadId);
+        Assert.Null(events[0].TurnId);
+        Assert.Equal("consolidationFailed", payload.Kind);
+        Assert.Equal("provider unavailable", payload.Message);
+    }
+
     private static async Task<List<SessionEvent>> CollectAsync(
         IAsyncEnumerable<SessionEvent> events,
         int expectedCount,

--- a/tests/DotCraft.Core.Tests/Tools/FileToolsConcurrencyTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/FileToolsConcurrencyTests.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using DotCraft.Tools;
+using Microsoft.Extensions.AI;
+
+namespace DotCraft.Tests.Tools;
+
+public class FileToolsConcurrencyTests
+{
+    [Fact]
+    public async Task EditFile_ParallelNonOverlappingEdits_AllSucceed()
+    {
+        var workspace = CreateWorkspace();
+        var filePath = Path.Combine(workspace, "notes.txt");
+        await File.WriteAllTextAsync(filePath, string.Join('\n', Enumerable.Range(0, 16).Select(i => $"[[anchor-{i}]]")));
+
+        var toolsA = new FileTools(workspace, requireApprovalOutsideWorkspace: false);
+        var toolsB = new FileTools(workspace, requireApprovalOutsideWorkspace: false);
+        var tasks = Enumerable.Range(0, 16)
+            .Select(i => (i % 2 == 0 ? toolsA : toolsB).EditFile("notes.txt", $"[[anchor-{i}]]", $"replacement-{i}"))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        Assert.All(results, result => Assert.False(
+            result.StartsWith("Error", StringComparison.Ordinal),
+            result));
+        var finalContent = await File.ReadAllTextAsync(filePath);
+        for (var i = 0; i < 16; i++)
+            Assert.Contains($"replacement-{i}", finalContent, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task EditFile_ParallelOverlappingEdits_FailsCleanly()
+    {
+        var workspace = CreateWorkspace();
+        await File.WriteAllTextAsync(Path.Combine(workspace, "notes.txt"), "shared");
+        var toolsA = new FileTools(workspace, requireApprovalOutsideWorkspace: false);
+        var toolsB = new FileTools(workspace, requireApprovalOutsideWorkspace: false);
+
+        var results = await Task.WhenAll(
+            toolsA.EditFile("notes.txt", "shared", "first"),
+            toolsB.EditFile("notes.txt", "shared", "second"));
+
+        Assert.Single(results, result => result.StartsWith("Successfully", StringComparison.Ordinal));
+        var error = Assert.Single(results, result => result.StartsWith("Error", StringComparison.Ordinal));
+        Assert.Contains("oldText not found", error, StringComparison.Ordinal);
+        Assert.DoesNotContain("being used by another process", string.Join('\n', results), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task WriteFile_ParallelWrites_LastWriterWinsNoError()
+    {
+        var workspace = CreateWorkspace();
+        var tools = new FileTools(workspace, requireApprovalOutsideWorkspace: false);
+        var inputs = Enumerable.Range(0, 16).Select(i => $"content-{i}").ToArray();
+
+        var results = await Task.WhenAll(inputs.Select(content => tools.WriteFile("notes.txt", content)));
+
+        Assert.All(results, result => Assert.StartsWith("Successfully wrote", result, StringComparison.Ordinal));
+        var finalContent = await File.ReadAllTextAsync(Path.Combine(workspace, "notes.txt"));
+        Assert.Contains(finalContent, inputs);
+    }
+
+    [Fact]
+    public async Task ReadFile_DoesNotBlockOnConcurrentReads()
+    {
+        var workspace = CreateWorkspace();
+        var content = string.Join('\n', Enumerable.Range(0, 100_000).Select(i => $"line-{i:D6}"));
+        await File.WriteAllTextAsync(Path.Combine(workspace, "large.txt"), content);
+        var tools = new FileTools(workspace, requireApprovalOutsideWorkspace: false);
+
+        var singleRead = Stopwatch.StartNew();
+        await tools.ReadFile("large.txt");
+        singleRead.Stop();
+
+        var parallelRead = Stopwatch.StartNew();
+        var results = await Task.WhenAll(Enumerable.Range(0, 16).Select(_ => tools.ReadFile("large.txt")));
+        parallelRead.Stop();
+
+        Assert.All(results, result =>
+        {
+            var text = Assert.Single(result.OfType<TextContent>());
+            Assert.Contains("line-000000", text.Text, StringComparison.Ordinal);
+        });
+        Assert.True(
+            parallelRead.ElapsedMilliseconds < Math.Max(singleRead.ElapsedMilliseconds * 12, 2_000),
+            $"Parallel reads took {parallelRead.ElapsedMilliseconds}ms after a single read took {singleRead.ElapsedMilliseconds}ms.");
+    }
+
+    private static string CreateWorkspace()
+    {
+        var workspace = Path.Combine(Path.GetTempPath(), "dotcraft-filetools-concurrency-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspace);
+        return workspace;
+    }
+}

--- a/tui/src/app/event_mapper.rs
+++ b/tui/src/app/event_mapper.rs
@@ -630,7 +630,7 @@ pub fn apply(state: &mut AppState, msg: &JsonRpcMessage) -> bool {
                         message: message.clone(),
                     });
                 }
-                "compacted" | "compactSkipped" | "consolidated" => {
+                "compacted" | "compactSkipped" | "consolidated" | "consolidationFailed" => {
                     state.system_status = None;
                     if let Some(msg) = message {
                         state
@@ -761,6 +761,43 @@ mod tests {
             result: None,
             error: None,
         }
+    }
+
+    #[test]
+    fn consolidation_failed_clears_system_status_and_records_message() {
+        let mut state = AppState::new("workspace".to_string());
+
+        assert!(apply(
+            &mut state,
+            &notification(
+                "system/event",
+                serde_json::json!({
+                    "kind": "consolidating",
+                    "message": "Consolidating memory"
+                })
+            )
+        ));
+        assert_eq!(
+            state.system_status.as_ref().map(|status| status.kind.as_str()),
+            Some("consolidating")
+        );
+
+        assert!(apply(
+            &mut state,
+            &notification(
+                "system/event",
+                serde_json::json!({
+                    "kind": "consolidationFailed",
+                    "message": "Memory consolidation failed"
+                })
+            )
+        ));
+
+        assert!(state.system_status.is_none());
+        assert!(matches!(
+            state.history.last(),
+            Some(HistoryEntry::SystemInfo { message }) if message == "Memory consolidation failed"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
- Introduced `memoryAutoConsolidateEnabled` field in the `WorkspaceCoreConfigSnapshot` interface and related functions to manage long-term memory consolidation settings.
- Updated IPC handlers, settings views, and tests to support the new memory consolidation feature.
- Enhanced UI components to include a toggle for enabling/disabling memory auto-consolidation, with appropriate state management and user feedback.
- Added localization strings for new memory settings and updated documentation to reflect changes in configuration options.
- Implemented tests to ensure proper functionality and integration of memory consolidation features across the application.